### PR TITLE
Throw ToolError and update Mealplan tools

### DIFF
--- a/src/tools/mealplan_tools.py
+++ b/src/tools/mealplan_tools.py
@@ -3,10 +3,10 @@ import traceback
 from typing import Any, Dict, List, Optional
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 
 from mealie import MealieFetcher
 from models.mealplan import MealPlanEntry
-from utils import format_error_response
 
 logger = logging.getLogger("mealie-mcp")
 
@@ -54,7 +54,7 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)
 
     @mcp.tool()
     def create_mealplan(
@@ -82,7 +82,7 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)
 
     @mcp.tool()
     def create_mealplan_bulk(
@@ -112,7 +112,7 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)
 
     @mcp.tool()
     def get_todays_mealplan() -> List[Dict[str, Any]]:
@@ -130,4 +130,4 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)

--- a/src/tools/mealplan_tools.py
+++ b/src/tools/mealplan_tools.py
@@ -58,12 +58,18 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
 
     @mcp.tool()
     def create_mealplan(
-        entry: MealPlanEntry,
+        date: str,
+        recipe_id: Optional[str] = None,
+        title: Optional[str] = None,
+        entry_type: str = "breakfast",
     ) -> Dict[str, Any]:
         """Create a new meal plan entry.
 
         Args:
-            entry: MealPlanEntry object containing date, recipe_id, title, and entry_type
+            date: Date for the mealplan in ISO format (YYYY-MM-DD)
+            recipe_id: UUID of the recipe to add to the mealplan (optional)
+            title: Title for the mealplan entry if not using a recipe (optional)
+            entry_type: Type of mealplan entry (breakfast, lunch, dinner, side)
 
         Returns:
             Dict[str, Any]: JSON response containing the created mealplan entry
@@ -72,10 +78,18 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.info(
                 {
                     "message": "Creating mealplan entry",
-                    "entry": entry.model_dump(),
+                    "date": date,
+                    "recipe_id": recipe_id,
+                    "title": title,
+                    "entry_type": entry_type,
                 }
             )
-            return mealie.create_mealplan(**entry.model_dump())
+            return mealie.create_mealplan(
+                date=date,
+                recipe_id=recipe_id,
+                title=title,
+                entry_type=entry_type,
+            )
         except Exception as e:
             error_msg = f"Error creating mealplan entry: {str(e)}"
             logger.error({"message": error_msg})
@@ -86,15 +100,19 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
 
     @mcp.tool()
     def create_mealplan_bulk(
-        entries: List[MealPlanEntry],
+        entries: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
         """Create multiple meal plan entries in bulk.
 
         Args:
-            entries: List of MealPlanEntry objects
-                containing date, recipe_id, title, and entry_type
+            entries: List of mealplan entries, each containing:
+                - date (str): Date in ISO format (YYYY-MM-DD)
+                - recipe_id (str, optional): UUID of the recipe
+                - title (str, optional): Title for the entry
+                - entry_type (str, optional): Type of entry (breakfast, lunch, dinner, side)
+
         Returns:
-            Dict[str, Any]: JSON response containing the created mealplan entries
+            Dict[str, Any]: JSON response with success message
         """
         try:
             logger.info(
@@ -104,8 +122,9 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 }
             )
             for entry in entries:
-                mealie.create_mealplan(**entry.model_dump())
-            return {"message": "Bulk mealplan entries created successfully"}
+                entry_obj = MealPlanEntry.model_validate(entry)
+                mealie.create_mealplan(**entry_obj.model_dump())
+            return {"message": f"Successfully created {len(entries)} mealplan entries"}
         except Exception as e:
             error_msg = f"Error creating bulk mealplan entries: {str(e)}"
             logger.error({"message": error_msg})

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -3,10 +3,10 @@ import traceback
 from typing import List, Optional
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 
 from mealie import MealieFetcher
 from models.recipe import Recipe, RecipeIngredient, RecipeInstruction
-from utils import format_error_response
 
 logger = logging.getLogger("mealie-mcp")
 
@@ -58,7 +58,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)
 
     @mcp.tool()
     def get_recipe_detailed(slug: str) -> str:
@@ -82,7 +82,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)
 
     @mcp.tool()
     def get_recipe_concise(slug: str) -> str:
@@ -108,7 +108,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                     "recipeYield",
                     "totalTime",
                     "rating",
-                      "recipeIngredient",
+                    "recipeIngredient",
                     "lastMade",
                 },
                 exclude_none=True,
@@ -119,7 +119,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)
 
     @mcp.tool()
     def create_recipe(
@@ -151,7 +151,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)
 
     @mcp.tool()
     def update_recipe(
@@ -184,4 +184,4 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
             )
-            return format_error_response(error_msg)
+            raise ToolError(error_msg)

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -1,6 +1,6 @@
 import logging
 import traceback
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
@@ -21,7 +21,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         per_page: Optional[int] = None,
         categories: Optional[List[str]] = None,
         tags: Optional[List[str]] = None,
-    ) -> str:
+    ) -> Dict[str, Any]:
         """Provides a paginated list of recipes with optional filtering.
 
         Args:
@@ -32,7 +32,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             tags: Filter by specific recipe tags.
 
         Returns:
-            str: Recipe summaries with details like ID, name, description, and image information.
+            Dict[str, Any]: Recipe summaries with details like ID, name, description, and image information.
         """
         try:
             logger.info(
@@ -61,7 +61,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             raise ToolError(error_msg)
 
     @mcp.tool()
-    def get_recipe_detailed(slug: str) -> str:
+    def get_recipe_detailed(slug: str) -> Dict[str, Any]:
         """Retrieve a specific recipe by its slug identifier. Use this when to get full recipe
         details for tasks like updating or displaying the recipe.
 
@@ -70,7 +70,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 or from get_recipes results.
 
         Returns:
-            str: Comprehensive recipe details including ingredients, instructions,
+            Dict[str, Any]: Comprehensive recipe details including ingredients, instructions,
                 nutrition information, notes, and associated metadata.
         """
         try:
@@ -85,7 +85,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             raise ToolError(error_msg)
 
     @mcp.tool()
-    def get_recipe_concise(slug: str) -> str:
+    def get_recipe_concise(slug: str) -> Dict[str, Any]:
         """Retrieve a concise version of a specific recipe by its slug identifier. Use this when you only
         need a summary of the recipe, such as for when mealplaning.
 
@@ -93,7 +93,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             slug: The unique text identifier for the recipe, typically found in recipe URLs
                 or from get_recipes results.
 
-
+        Returns:
+            Dict[str, Any]: Concise recipe summary with essential fields.
         """
         try:
             logger.info({"message": "Fetching recipe", "slug": slug})
@@ -123,8 +124,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
 
     @mcp.tool()
     def create_recipe(
-        name: str, ingredients: list[str], instructions: list[str]
-    ) -> str:
+        name: str, ingredients: List[str], instructions: List[str]
+    ) -> Dict[str, Any]:
         """Create a new recipe
 
         Args:
@@ -133,7 +134,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             instructions: A list of instructions for preparing the recipe.
 
         Returns:
-            str: Confirmation message or details about the created recipe.
+            Dict[str, Any]: The created recipe details.
         """
         try:
             logger.info({"message": "Creating recipe", "name": name})
@@ -156,9 +157,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
     @mcp.tool()
     def update_recipe(
         slug: str,
-        ingredients: list[str],
-        instructions: list[str],
-    ) -> str:
+        ingredients: List[str],
+        instructions: List[str],
+    ) -> Dict[str, Any]:
         """Replaces the ingredients and instructions of an existing recipe.
 
         Args:
@@ -167,7 +168,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             instructions: A list of instructions for preparing the recipe.
 
         Returns:
-            str: Confirmation message or details about the updated recipe.
+            Dict[str, Any]: The updated recipe details.
         """
         try:
             logger.info({"message": "Updating recipe", "slug": slug})

--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.12.0" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
 ]


### PR DESCRIPTION
## Changes
- Update to throw ToolErrors instead of returning JSON containing errors
- Flatten MealPlan tool call params to resolve issue with MultiMCP schema check

