### PR TITLE
fix: correct RecipeIngredient field types to match Mealie API response

### DIFF
--- a/src/models/recipe.py
+++ b/src/models/recipe.py
@@ -3,10 +3,39 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 
+class IngredientUnit(BaseModel):
+    id: Optional[str] = None
+    name: str
+    pluralName: Optional[str] = None
+    description: str = ""
+    extras: Optional[Dict[str, Any]] = None
+    fraction: bool = True
+    abbreviation: str = ""
+    pluralAbbreviation: Optional[str] = ""
+    useAbbreviation: bool = False
+    aliases: List[Any] = Field(default_factory=list)
+    createdAt: Optional[str] = None
+    updatedAt: Optional[str] = None
+
+
+class IngredientFood(BaseModel):
+    id: Optional[str] = None
+    name: str
+    pluralName: Optional[str] = None
+    description: str = ""
+    extras: Optional[Dict[str, Any]] = None
+    labelId: Optional[str] = None
+    label: Optional[Any] = None
+    aliases: List[Any] = Field(default_factory=list)
+    householdsWithIngredientFood: List[str] = Field(default_factory=list)
+    createdAt: Optional[str] = None
+    updatedAt: Optional[str] = None
+
+
 class RecipeIngredient(BaseModel):
     quantity: Optional[float] = None
-    unit: Optional[str] = None
-    food: Optional[str] = None
+    unit: Optional[IngredientUnit] = None
+    food: Optional[IngredientFood] = None
     note: str
     isFood: Optional[bool] = True
     disableAmount: Optional[bool] = False

--- a/src/models/recipe.py
+++ b/src/models/recipe.py
@@ -36,7 +36,7 @@ class RecipeIngredient(BaseModel):
     quantity: Optional[float] = None
     unit: Optional[IngredientUnit] = None
     food: Optional[IngredientFood] = None
-    note: str
+    note: Optional[str] = None
     isFood: Optional[bool] = True
     disableAmount: Optional[bool] = False
     display: Optional[str] = None


### PR DESCRIPTION
###  Problem
  `update_recipe` and `create_recipe` failed for recipes with structured ingredient data. Both tools call
  `Recipe.model_validate(recipe_json)` to load the existing recipe before modifying it, and the Mealie API response
  didn't match the `RecipeIngredient` model in two ways:
  1. `unit` and `food` typed as `Optional[str]` — the API returns these as full nested objects (`IngredientUnit` /
  `IngredientFood`), causing Pydantic to raise validation errors for every ingredient that had a unit or food set.
  2. note typed as `str` — the API returns null for some ingredients, causing a Input should be a valid string
  validation error.
  Both issues were confirmed against the bundled openapi.json spec.

###  Fix
  - Add `IngredientUnit` and `IngredientFood` Pydantic models matching the `IngredientUnit-Output` and
  `IngredientFood-Output` schemas from the Mealie OpenAPI spec, and update `RecipeIngredient.unit` / `.food` to use
  them.
  - Change `RecipeIngredient.note` from `str` to `Optional[str] = None.`

###  Testing
No existing tests in the repo but I verified this agains an application I'm working on which uses this mcp server.
Verified black and isort pass with no changes.