### PR TITLE
feat: Add delete mealplan tool

### DIFF
--- a/src/mealie/mealplan.py
+++ b/src/mealie/mealplan.py
@@ -92,6 +92,25 @@ class MealplanMixin:
         )
         return self._handle_request("POST", "/api/households/mealplans", json=payload)
 
+    def delete_mealplan(self, item_id: str) -> Dict[str, Any]:
+        """Delete a specific mealplan entry.
+
+        Args:
+            item_id: The ID of the mealplan entry to delete
+
+        Returns:
+            JSON response confirming deletion
+
+        Raises:
+            ValueError: If item_id is empty
+            MealieApiError: If the API request fails
+        """
+        if not item_id:
+            raise ValueError("Mealplan entry ID cannot be empty")
+
+        logger.info({"message": "Deleting mealplan entry", "item_id": item_id})
+        return self._handle_request("DELETE", f"/api/households/mealplans/{item_id}")
+
     def get_todays_mealplan(self) -> List[Dict[str, Any]]:
         """Get the mealplan entries for today.
 

--- a/src/tools/mealplan_tools.py
+++ b/src/tools/mealplan_tools.py
@@ -134,6 +134,27 @@ def register_mealplan_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             raise ToolError(error_msg)
 
     @mcp.tool()
+    def delete_mealplan(item_id: str) -> Dict[str, Any]:
+        """Delete a specific meal plan entry.
+
+        Args:
+            item_id: The ID of the mealplan entry to delete
+
+        Returns:
+            Dict[str, Any]: Confirmation of deletion
+        """
+        try:
+            logger.info({"message": "Deleting mealplan entry", "item_id": item_id})
+            return mealie.delete_mealplan(item_id)
+        except Exception as e:
+            error_msg = f"Error deleting mealplan entry '{item_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
     def get_todays_mealplan() -> List[Dict[str, Any]]:
         """Get the mealplan entries for today.
 


### PR DESCRIPTION
Hello, I wanted the bot to be able to delete a meal plan item from the meal plan.

This option didn't seem to exist in the MCP.

With this addition, my bot was able to delete a meal plan item that I no longer wanted on the plan.