### PR TITLE
feat: add import_recipe_from_url tool (POST /api/recipes/create/url)

### DIFF
--- a/API_COVERAGE.md
+++ b/API_COVERAGE.md
@@ -31,9 +31,9 @@ This document compares the MCP server implementation against the official Mealie
 - ✅ `POST /api/recipes/{slug}/assets` - Upload asset file
 - ✅ `GET /api/recipes/suggestions` - Get recipe suggestions (via search)
 - ✅ Advanced filtering with AND/OR logic for tags/categories
+- ✅ `POST /api/recipes/create/url` - Create from URL
 
 **Not Yet Implemented:**
-- ⏳ `POST /api/recipes/create/url` - Create from URL
 - ⏳ `POST /api/recipes/create/url/bulk` - Bulk create from URLs
 - ⏳ `POST /api/recipes/create/zip` - Create from ZIP
 - ⏳ `POST /api/recipes/create/html-or-json` - Create from HTML/JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ This release adds **44+ new API operations** across shopping lists, categories, 
   - `upload_recipe_image_file` - Upload image file (multipart)
   - `upload_recipe_asset_file` - Upload asset/document file (multipart)
 
+- **URL Import**
+  - `import_recipe_from_url` - Create a recipe by scraping a URL using Mealie's server-side scraper (`recipe-scrapers` library); returns the created recipe so callers can verify the scrape result
+
 - **Advanced Filtering**
   - `require_all_tags` - AND logic for tag filtering (default: OR)
   - `require_all_categories` - AND logic for category filtering

--- a/src/mealie/recipe.py
+++ b/src/mealie/recipe.py
@@ -115,6 +115,32 @@ class RecipeMixin:
         logger.info({"message": "Creating new recipe", "name": name})
         return self._handle_request("POST", "/api/recipes", json={"name": name})
 
+    def import_recipe_from_url(
+        self, url: str, include_tags: bool = False
+    ) -> str:
+        """Create a recipe by scraping a URL using Mealie's built-in scraper
+
+        Mealie's server uses the `recipe-scrapers` library, which has built-in
+        adapters for major recipe sites and falls back to JSON-LD/Schema.org
+        parsing for other sites.
+
+        Args:
+            url: Source URL of the recipe to import
+            include_tags: If True, import tags Mealie extracts from the source
+
+        Returns:
+            Slug of the newly created recipe
+        """
+        if not url:
+            raise ValueError("URL cannot be empty")
+
+        logger.info({"message": "Importing recipe from URL", "url": url})
+        return self._handle_request(
+            "POST",
+            "/api/recipes/create/url",
+            json={"url": url, "includeTags": include_tags},
+        )
+
     def patch_recipe(self, slug: str, recipe_data: Dict[str, Any]) -> Dict[str, Any]:
         """Partially update a recipe (only updates provided fields)
 

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -169,6 +169,45 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             raise ToolError(error_msg)
 
     @mcp.tool()
+    def import_recipe_from_url(
+        url: str, include_tags: bool = False
+    ) -> Dict[str, Any]:
+        """Import a recipe into Mealie by scraping a URL.
+
+        Uses Mealie's server-side scraper (the `recipe-scrapers` library), which
+        has built-in adapters for many recipe sites and falls back to
+        JSON-LD/Schema.org parsing for sites without a dedicated adapter.
+        Coverage varies by Mealie version; URLs the scraper can't parse return
+        a 400 from Mealie.
+
+        The created recipe is fetched and returned so the caller can verify the
+        scrape result. Some sources (notably paywalled URLs that redirect) can
+        cause the scraper to land on the wrong page and silently return the
+        wrong recipe — always confirm the returned `name` matches what was
+        requested.
+
+        Args:
+            url: Source URL of the recipe to import.
+            include_tags: If True, import tags Mealie extracts from the source.
+                Defaults to False.
+
+        Returns:
+            Dict[str, Any]: The created recipe, including slug, name,
+            ingredients, and instructions.
+        """
+        try:
+            logger.info({"message": "Importing recipe from URL", "url": url})
+            slug = mealie.import_recipe_from_url(url, include_tags=include_tags)
+            return mealie.get_recipe(slug)
+        except Exception as e:
+            error_msg = f"Error importing recipe from URL '{url}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
     def update_recipe(
         slug: str,
         ingredients: List[str],


### PR DESCRIPTION
## Summary

Adds `import_recipe_from_url`, an MCP tool that wraps Mealie's `POST /api/recipes/create/url` endpoint. Closes the gap explicitly listed in `API_COVERAGE.md` (`⏳ POST /api/recipes/create/url - Create from URL`) and called out as a v1.1 milestone goal.

The implementation is intentionally minimal: a thin pass-through to Mealie's own scraper (the `recipe-scrapers` library that ships with Mealie). The tool fetches and returns the created recipe so callers can verify what was actually scraped — important because some sources (notably paywalled URLs that redirect) can cause Mealie's scraper to silently land on the wrong page.

## Relationship to #7

PR #7 also adds URL import but takes a different approach: in-MCP scraping with custom JSON-LD parsing, currently scoped to `ah.nl/allerhande`. The two are largely complementary — this PR delegates to Mealie's server-side scraper (works for any site `recipe-scrapers` supports, no per-site code), while #7 adds an in-MCP fallback for sites Mealie can't handle. They use the same tool name, however, so a naming decision is needed if both merge — happy to rename either way.

## Test plan

- [x] Module imports cleanly with the new tool registered (45 tools, was 44)
- [x] End-to-end against a live Mealie instance: `import_recipe_from_url("https://www.pressurecookrecipes.com/instant-pot-chili/")` → returns the new recipe with 21 ingredients and 7 instructions, slug verified, recipe deleted afterward
- [x] URL the scraper can't handle returns a 400 — caller sees the wrapped error, no silent failure
- [ ] Reviewer test: any site Mealie's scraper supports

🤖 Generated with [Claude Code](https://claude.com/claude-code)