### PR TITLE
feat(recipe): structured ingredients, create_recipe_full, and foods/units/tools CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to the Mealie MCP Server.
 
+## [Unreleased]
+
+### ✨ New Features
+
+- **`create_recipe_full`** - Create a recipe and populate all of its content
+  in a single call: description, timing (total/prep/cook/perform), servings,
+  source URL (`orgURL`), structured or flat ingredients, preparation steps, and
+  an optional image scraped from a URL.
+- **Structured ingredients & step links** - `create_recipe` and `update_recipe`
+  now accept, per item, either a flat string (parsed by Mealie's NLP as before)
+  or a structured object with `quantity`, `note`, `title`, `referenceId`, and an
+  existing Mealie `unit`/`food`. Instruction steps accept `ingredientReferences`
+  to enable Mealie's cook-mode highlighting; `referenceId` accepts any string
+  (mapped to a stable UUID v4, which Mealie requires) — reuse the same value on
+  a step to keep the link. Flat-string usage is unchanged.
+- **`patch_recipe`** - Added `org_url`, `prep_time`, `cook_time`, `perform_time`,
+  and `servings` to the partial-update fields.
+- **Foods, units & tools management** - Full CRUD for the household's foods
+  (`get_foods`, `create_food`, `get_food`, `update_food`, `delete_food`), units
+  (same set), and recipe tools (same set plus `get_tool_by_slug`). The `get_*`
+  lookups resolve ids for structured ingredients and tool assignment without
+  hardcoding UUIDs; `get_tools` exposes `householdsWithTool` to distinguish
+  owned tools from database-only entries.
+- **Tag & tool assignment** - `create_recipe_full` and `patch_recipe` accept
+  `tags` and `tools` (each `{ id, name }`; the `slug` Mealie requires is derived
+  from the name when omitted) to assign existing organizers.
+- **`get_recipe_concise`** - Now also returns `orgURL`, `tags`, and `tools`,
+  enabling a lightweight duplicate check by source URL.
+
+### 🐛 Bug Fixes
+
+- **Recipe time fields typed as text** - `Recipe.totalTime`/`prepTime`/`cookTime`/
+  `performTime` were typed as `int` but the Mealie API returns them as strings
+  (e.g. `"30 Minutes"`, `"PT35M"`). Validating such recipes raised
+  `Input should be a valid integer` in `get_recipe_concise`, `create_recipe`, and
+  `update_recipe`. They are now typed as `str`, matching the API.
+- **Instruction ingredient references typed as objects** -
+  `RecipeInstruction.ingredientReferences` was typed as `list[str]`; the Mealie
+  API uses `[{ "referenceId": ... }]`. It is now typed accordingly so recipes
+  with step/ingredient links validate.
+- **Tags/tools/categories typed as objects** - `Recipe.tags`, `Recipe.tools`,
+  and `Recipe.recipeCategory` were typed as `list[str]` but the Mealie API
+  returns objects (`{ id, name, slug }`). Validating a recipe that has any of
+  these raised `Input should be a valid string`; they are now typed as objects.
+
+### 🧪 Tests
+
+- Added a `pytest` suite (`tests/`) covering the recipe-authoring tools
+  (structured ingredients, `create_recipe_full`, `patch_recipe`,
+  `get_recipe_concise`), the foods/units/tools CRUD tools, and the model
+  typing fixes. Tests run offline against a fake Mealie client that records
+  the HTTP requests the mixins build. `pytest`/`pytest-asyncio` added to the
+  `dev` extra.
+
+### 🔄 Breaking Changes
+
+**None** - Existing flat-string calls to `create_recipe`/`update_recipe` and the
+previous `patch_recipe` fields continue to work unchanged.
+
 ## [Unreleased] - 2025-01-05
 
 ### 🎉 Major Feature Additions

--- a/README.md
+++ b/README.md
@@ -117,11 +117,12 @@ Restart Claude Desktop to load the server.
 
 ## 🎯 Available Tools
 
-### Recipe Tools (13 operations)
+### Recipe Tools (14 operations)
 - `get_recipes` - List/search recipes with advanced filtering
 - `get_recipe_detailed` - Get complete recipe details
 - `get_recipe_concise` - Get recipe summary
-- `create_recipe` - Create new recipe
+- `create_recipe` - Create new recipe (flat or structured ingredients)
+- `create_recipe_full` - Create a recipe with full content in one call
 - `update_recipe` - Update recipe (full replacement)
 - `patch_recipe` - Update specific fields only
 - `duplicate_recipe` - Clone a recipe
@@ -165,13 +166,35 @@ Restart Claude Desktop to load the server.
 - `update_tag` - Update tag
 - `delete_tag` - Delete tag
 
+### Food Tools (5 operations)
+- `get_foods` - List/search foods (resolve ids for structured ingredients)
+- `create_food` - Create a new food
+- `get_food` - Get by ID
+- `update_food` - Update food
+- `delete_food` - Delete food
+
+### Unit Tools (5 operations)
+- `get_units` - List/search units
+- `create_unit` - Create a new unit
+- `get_unit` - Get by ID
+- `update_unit` - Update unit
+- `delete_unit` - Delete unit
+
+### Recipe Tool Tools (6 operations)
+- `get_tools` - List/search recipe tools (includes `householdsWithTool`)
+- `create_tool` - Create a new tool
+- `get_tool` - Get by ID
+- `get_tool_by_slug` - Get by slug
+- `update_tool` - Update tool
+- `delete_tool` - Delete tool
+
 ### Meal Plan Tools (4 operations)
 - `get_all_mealplans` - List meal plans
 - `create_mealplan` - Create meal plan entry
 - `create_mealplan_bulk` - Create multiple entries
 - `get_todays_mealplan` - Get today's meals
 
-**Total: 45 tools** providing comprehensive Mealie API coverage
+**Total: 62 tools** providing comprehensive Mealie API coverage
 
 ## 🔧 Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,14 @@ use_parentheses = true
 ensure_newline_before_comments = true
 
 [project.optional-dependencies]
-dev = ["black>=24.1.0", "isort>=5.13.0"]
+dev = [
+    "black>=24.1.0",
+    "isort>=5.13.0",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/mealie/__init__.py
+++ b/src/mealie/__init__.py
@@ -1,10 +1,13 @@
 from .categories import CategoriesMixin
 from .client import MealieClient
+from .foods import FoodsMixin
 from .group import GroupMixin
 from .mealplan import MealplanMixin
 from .recipe import RecipeMixin
 from .shopping_list import ShoppingListMixin
 from .tags import TagsMixin
+from .tools import ToolsMixin
+from .units import UnitsMixin
 from .user import UserMixin
 
 
@@ -12,6 +15,9 @@ class MealieFetcher(
     RecipeMixin,
     CategoriesMixin,
     TagsMixin,
+    FoodsMixin,
+    UnitsMixin,
+    ToolsMixin,
     ShoppingListMixin,
     MealplanMixin,
     UserMixin,

--- a/src/mealie/foods.py
+++ b/src/mealie/foods.py
@@ -1,0 +1,123 @@
+import logging
+from typing import Any, Dict, Optional
+
+from utils import format_api_params
+
+logger = logging.getLogger("mealie-mcp")
+
+
+class FoodsMixin:
+    """Mixin class for food-related API endpoints (/api/foods)."""
+
+    def get_foods(
+        self,
+        search: Optional[str] = None,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+        query_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List the household's foods (optionally filtered by search term).
+
+        Args:
+            search: Search term to filter foods by name/alias
+            page: Page number to retrieve
+            per_page: Number of items per page
+            query_filter: Advanced query filter
+
+        Returns:
+            JSON response containing food items and pagination information
+        """
+        param_dict = {
+            "search": search,
+            "page": page,
+            "perPage": per_page,
+            "queryFilter": query_filter,
+        }
+        params = format_api_params(param_dict)
+
+        logger.info({"message": "Retrieving foods", "parameters": params})
+        return self._handle_request("GET", "/api/foods", params=params)
+
+    def create_food(
+        self,
+        name: str,
+        plural_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a new food.
+
+        Args:
+            name: Name of the food
+            plural_name: Optional plural name
+            description: Optional description
+
+        Returns:
+            JSON response containing the created food
+        """
+        if not name:
+            raise ValueError("Food name cannot be empty")
+
+        payload: Dict[str, Any] = {"name": name}
+        if plural_name is not None:
+            payload["pluralName"] = plural_name
+        if description is not None:
+            payload["description"] = description
+
+        logger.info({"message": "Creating food", "name": name})
+        return self._handle_request("POST", "/api/foods", json=payload)
+
+    def get_food(self, food_id: str) -> Dict[str, Any]:
+        """Get a specific food by ID.
+
+        Args:
+            food_id: The UUID of the food
+
+        Returns:
+            JSON response containing the food details
+        """
+        if not food_id:
+            raise ValueError("Food ID cannot be empty")
+
+        logger.info({"message": "Retrieving food", "food_id": food_id})
+        return self._handle_request("GET", f"/api/foods/{food_id}")
+
+    def update_food(self, food_id: str, food_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a specific food.
+
+        Mealie's PUT replaces the whole record, so we fetch the existing food
+        and merge the provided fields over it. This both preserves fields the
+        caller did not set and keeps the required ``id``/``name`` in the body
+        (a partial body would null them and fail).
+
+        Args:
+            food_id: The UUID of the food to update
+            food_data: Dictionary containing the food properties to update
+
+        Returns:
+            JSON response containing the updated food
+        """
+        if not food_id:
+            raise ValueError("Food ID cannot be empty")
+        if not food_data:
+            raise ValueError("Food data cannot be empty")
+
+        existing = self.get_food(food_id)
+        merged = {**existing, **food_data} if isinstance(existing, dict) else food_data
+
+        logger.info({"message": "Updating food", "food_id": food_id})
+        return self._handle_request("PUT", f"/api/foods/{food_id}", json=merged)
+
+    def delete_food(self, food_id: str) -> Dict[str, Any]:
+        """Delete a specific food.
+
+        Args:
+            food_id: The UUID of the food to delete
+
+        Returns:
+            JSON response confirming deletion
+        """
+        if not food_id:
+            raise ValueError("Food ID cannot be empty")
+
+        logger.info({"message": "Deleting food", "food_id": food_id})
+        return self._handle_request("DELETE", f"/api/foods/{food_id}")

--- a/src/mealie/tools.py
+++ b/src/mealie/tools.py
@@ -1,0 +1,131 @@
+import logging
+from typing import Any, Dict, Optional
+
+from utils import format_api_params
+
+logger = logging.getLogger("mealie-mcp")
+
+
+class ToolsMixin:
+    """Mixin class for recipe-tool API endpoints (/api/organizers/tools)."""
+
+    def get_tools(
+        self,
+        search: Optional[str] = None,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+        query_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List the household's recipe tools (optionally filtered by search term).
+
+        Each tool includes ``householdsWithTool``, which distinguishes tools the
+        household owns from tools that merely exist in the database.
+
+        Args:
+            search: Search term to filter tools by name
+            page: Page number to retrieve
+            per_page: Number of items per page
+            query_filter: Advanced query filter
+
+        Returns:
+            JSON response containing tool items and pagination information
+        """
+        param_dict = {
+            "search": search,
+            "page": page,
+            "perPage": per_page,
+            "queryFilter": query_filter,
+        }
+        params = format_api_params(param_dict)
+
+        logger.info({"message": "Retrieving tools", "parameters": params})
+        return self._handle_request("GET", "/api/organizers/tools", params=params)
+
+    def create_tool(self, name: str) -> Dict[str, Any]:
+        """Create a new recipe tool.
+
+        Args:
+            name: Name of the tool (e.g. "Kochtopf", "Backofen")
+
+        Returns:
+            JSON response containing the created tool
+        """
+        if not name:
+            raise ValueError("Tool name cannot be empty")
+
+        payload = {"name": name}
+
+        logger.info({"message": "Creating tool", "name": name})
+        return self._handle_request("POST", "/api/organizers/tools", json=payload)
+
+    def get_tool(self, tool_id: str) -> Dict[str, Any]:
+        """Get a specific tool by ID.
+
+        Args:
+            tool_id: The UUID of the tool
+
+        Returns:
+            JSON response containing the tool details
+        """
+        if not tool_id:
+            raise ValueError("Tool ID cannot be empty")
+
+        logger.info({"message": "Retrieving tool", "tool_id": tool_id})
+        return self._handle_request("GET", f"/api/organizers/tools/{tool_id}")
+
+    def get_tool_by_slug(self, tool_slug: str) -> Dict[str, Any]:
+        """Get a specific tool by its slug.
+
+        Args:
+            tool_slug: The slug of the tool
+
+        Returns:
+            JSON response containing the tool details
+        """
+        if not tool_slug:
+            raise ValueError("Tool slug cannot be empty")
+
+        logger.info({"message": "Retrieving tool by slug", "tool_slug": tool_slug})
+        return self._handle_request("GET", f"/api/organizers/tools/slug/{tool_slug}")
+
+    def update_tool(self, tool_id: str, tool_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a specific tool.
+
+        Mealie's PUT replaces the whole record, so we fetch the existing tool
+        and merge the provided fields over it (preserving unset fields and
+        keeping the required ``id``/``name`` in the body).
+
+        Args:
+            tool_id: The UUID of the tool to update
+            tool_data: Dictionary containing the tool properties to update
+
+        Returns:
+            JSON response containing the updated tool
+        """
+        if not tool_id:
+            raise ValueError("Tool ID cannot be empty")
+        if not tool_data:
+            raise ValueError("Tool data cannot be empty")
+
+        existing = self.get_tool(tool_id)
+        merged = {**existing, **tool_data} if isinstance(existing, dict) else tool_data
+
+        logger.info({"message": "Updating tool", "tool_id": tool_id})
+        return self._handle_request(
+            "PUT", f"/api/organizers/tools/{tool_id}", json=merged
+        )
+
+    def delete_tool(self, tool_id: str) -> Dict[str, Any]:
+        """Delete a specific tool.
+
+        Args:
+            tool_id: The UUID of the tool to delete
+
+        Returns:
+            JSON response confirming deletion
+        """
+        if not tool_id:
+            raise ValueError("Tool ID cannot be empty")
+
+        logger.info({"message": "Deleting tool", "tool_id": tool_id})
+        return self._handle_request("DELETE", f"/api/organizers/tools/{tool_id}")

--- a/src/mealie/units.py
+++ b/src/mealie/units.py
@@ -1,0 +1,126 @@
+import logging
+from typing import Any, Dict, Optional
+
+from utils import format_api_params
+
+logger = logging.getLogger("mealie-mcp")
+
+
+class UnitsMixin:
+    """Mixin class for unit-related API endpoints (/api/units)."""
+
+    def get_units(
+        self,
+        search: Optional[str] = None,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+        query_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List the household's units (optionally filtered by search term).
+
+        Args:
+            search: Search term to filter units by name/abbreviation
+            page: Page number to retrieve
+            per_page: Number of items per page
+            query_filter: Advanced query filter
+
+        Returns:
+            JSON response containing unit items and pagination information
+        """
+        param_dict = {
+            "search": search,
+            "page": page,
+            "perPage": per_page,
+            "queryFilter": query_filter,
+        }
+        params = format_api_params(param_dict)
+
+        logger.info({"message": "Retrieving units", "parameters": params})
+        return self._handle_request("GET", "/api/units", params=params)
+
+    def create_unit(
+        self,
+        name: str,
+        abbreviation: Optional[str] = None,
+        plural_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a new unit.
+
+        Args:
+            name: Name of the unit
+            abbreviation: Optional short form (e.g. "g", "ml")
+            plural_name: Optional plural name
+            description: Optional description
+
+        Returns:
+            JSON response containing the created unit
+        """
+        if not name:
+            raise ValueError("Unit name cannot be empty")
+
+        payload: Dict[str, Any] = {"name": name}
+        if abbreviation is not None:
+            payload["abbreviation"] = abbreviation
+        if plural_name is not None:
+            payload["pluralName"] = plural_name
+        if description is not None:
+            payload["description"] = description
+
+        logger.info({"message": "Creating unit", "name": name})
+        return self._handle_request("POST", "/api/units", json=payload)
+
+    def get_unit(self, unit_id: str) -> Dict[str, Any]:
+        """Get a specific unit by ID.
+
+        Args:
+            unit_id: The UUID of the unit
+
+        Returns:
+            JSON response containing the unit details
+        """
+        if not unit_id:
+            raise ValueError("Unit ID cannot be empty")
+
+        logger.info({"message": "Retrieving unit", "unit_id": unit_id})
+        return self._handle_request("GET", f"/api/units/{unit_id}")
+
+    def update_unit(self, unit_id: str, unit_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Update a specific unit.
+
+        Mealie's PUT replaces the whole record, so we fetch the existing unit
+        and merge the provided fields over it (preserving unset fields and
+        keeping the required ``id``/``name`` in the body).
+
+        Args:
+            unit_id: The UUID of the unit to update
+            unit_data: Dictionary containing the unit properties to update
+
+        Returns:
+            JSON response containing the updated unit
+        """
+        if not unit_id:
+            raise ValueError("Unit ID cannot be empty")
+        if not unit_data:
+            raise ValueError("Unit data cannot be empty")
+
+        existing = self.get_unit(unit_id)
+        merged = {**existing, **unit_data} if isinstance(existing, dict) else unit_data
+
+        logger.info({"message": "Updating unit", "unit_id": unit_id})
+        return self._handle_request("PUT", f"/api/units/{unit_id}", json=merged)
+
+    def delete_unit(self, unit_id: str) -> Dict[str, Any]:
+        """Delete a specific unit.
+
+        Args:
+            unit_id: The UUID of the unit to delete
+
+        Returns:
+            JSON response confirming deletion
+        """
+        if not unit_id:
+            raise ValueError("Unit ID cannot be empty")
+
+        logger.info({"message": "Deleting unit", "unit_id": unit_id})
+        return self._handle_request("DELETE", f"/api/units/{unit_id}")

--- a/src/models/recipe.py
+++ b/src/models/recipe.py
@@ -45,12 +45,16 @@ class RecipeIngredient(BaseModel):
     referenceId: Optional[str] = None
 
 
+class IngredientReference(BaseModel):
+    referenceId: Optional[str] = None
+
+
 class RecipeInstruction(BaseModel):
     id: Optional[str] = None
     title: Optional[str] = None
     summary: Optional[str] = None
     text: str
-    ingredientReferences: List[str] = Field(default_factory=list)
+    ingredientReferences: List[IngredientReference] = Field(default_factory=list)
 
 
 class RecipeNutrition(BaseModel):
@@ -77,6 +81,25 @@ class RecipeSettings(BaseModel):
     locked: bool = False
 
 
+class RecipeCategory(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class RecipeTag(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+
+
+class RecipeTool(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    householdsWithTool: List[str] = Field(default_factory=list)
+
+
 class Recipe(BaseModel):
     id: str
     userId: str
@@ -88,14 +111,14 @@ class Recipe(BaseModel):
     recipeServings: Optional[int] = None
     recipeYieldQuantity: Optional[int] = 0
     recipeYield: Optional[str] = None
-    totalTime: Optional[int] = None
-    prepTime: Optional[int] = None
-    cookTime: Optional[int] = None
-    performTime: Optional[int] = None
+    totalTime: Optional[str] = None
+    prepTime: Optional[str] = None
+    cookTime: Optional[str] = None
+    performTime: Optional[str] = None
     description: Optional[str] = None
-    recipeCategory: List[str] = Field(default_factory=list)
-    tags: List[str] = Field(default_factory=list)
-    tools: List[str] = Field(default_factory=list)
+    recipeCategory: List[RecipeCategory] = Field(default_factory=list)
+    tags: List[RecipeTag] = Field(default_factory=list)
+    tools: List[RecipeTool] = Field(default_factory=list)
     rating: Optional[float] = None
     orgURL: Optional[str] = None
     dateAdded: str
@@ -111,3 +134,81 @@ class Recipe(BaseModel):
     notes: List[Any] = Field(default_factory=list)
     extras: Dict[str, Any] = Field(default_factory=dict)
     comments: List[Any] = Field(default_factory=list)
+
+
+class RecipeIngredientInput(BaseModel):
+    """Structured ingredient accepted by the create/update recipe tools.
+
+    Pass a plain string instead of this object to let Mealie's
+    natural-language parser resolve the quantity, unit, and food.
+    """
+
+    referenceId: Optional[str] = Field(
+        default=None,
+        description=(
+            "Id used to link instruction steps to this ingredient. Mealie stores "
+            "it as a UUID v4; any string is accepted and non-v4 values are "
+            "converted to a stable UUID v4 server-side. Reuse the same value on "
+            "the step's ingredientReferences to keep the link."
+        ),
+    )
+    quantity: Optional[float] = Field(
+        default=None, description="Numeric amount, e.g. 200."
+    )
+    unit: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Existing Mealie unit object. Mealie requires both the id and the "
+            'name, e.g. {"id": "<uuid>", "name": "gram"}.'
+        ),
+    )
+    food: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Existing Mealie food object. Mealie requires both the id and the "
+            'name, e.g. {"id": "<uuid>", "name": "rice"}.'
+        ),
+    )
+    note: Optional[str] = Field(
+        default=None,
+        description='Free-text qualifier shown after the food, e.g. "Basmati".',
+    )
+    title: Optional[str] = Field(
+        default=None, description="Section heading rendered above this ingredient."
+    )
+
+
+class RecipeInstructionInput(BaseModel):
+    """Structured preparation step accepted by the create/update recipe tools.
+
+    Pass a plain string instead of this object for a step that has no title
+    and no ingredient links.
+    """
+
+    text: str = Field(description="The instruction text for this step.")
+    title: Optional[str] = Field(
+        default=None, description="Optional heading for this step or section."
+    )
+    ingredientReferences: Optional[List[IngredientReference]] = Field(
+        default=None,
+        description=(
+            "referenceIds of the ingredients used in this step; must match the "
+            "referenceId set on those ingredients (Mealie requires UUID v4 here; "
+            "non-v4 values are converted to a stable UUID v4 server-side). "
+            "Enables Mealie's cook-mode highlighting."
+        ),
+    )
+
+
+class OrganizerRef(BaseModel):
+    """Reference to an existing Mealie tag, category, or tool.
+
+    Look up ids with get_tags / get_categories / get_tools. Mealie requires
+    both the id and the name.
+    """
+
+    id: str = Field(description="UUID of the existing organizer.")
+    name: str = Field(description="Display name of the existing organizer.")
+    slug: Optional[str] = Field(
+        default=None, description="Optional slug; Mealie derives it when omitted."
+    )

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,8 +1,11 @@
 from .categories_tools import register_categories_tools
+from .foods_tools import register_foods_tools
 from .mealplan_tools import register_mealplan_tools
 from .recipe_tools import register_recipe_tools
 from .shopping_list_tools import register_shopping_list_tools
 from .tags_tools import register_tags_tools
+from .tools_tools import register_tools_tools
+from .units_tools import register_units_tools
 
 
 def register_all_tools(mcp, mealie):
@@ -10,6 +13,9 @@ def register_all_tools(mcp, mealie):
     register_recipe_tools(mcp, mealie)
     register_categories_tools(mcp, mealie)
     register_tags_tools(mcp, mealie)
+    register_foods_tools(mcp, mealie)
+    register_units_tools(mcp, mealie)
+    register_tools_tools(mcp, mealie)
     register_shopping_list_tools(mcp, mealie)
     register_mealplan_tools(mcp, mealie)
 
@@ -19,6 +25,9 @@ __all__ = [
     "register_recipe_tools",
     "register_categories_tools",
     "register_tags_tools",
+    "register_foods_tools",
+    "register_units_tools",
+    "register_tools_tools",
     "register_shopping_list_tools",
     "register_mealplan_tools",
 ]

--- a/src/tools/foods_tools.py
+++ b/src/tools/foods_tools.py
@@ -1,0 +1,160 @@
+import logging
+import traceback
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from mealie import MealieFetcher
+
+logger = logging.getLogger("mealie-mcp")
+
+
+def register_foods_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
+    """Register all food-related tools with the MCP server."""
+
+    @mcp.tool()
+    def get_foods(
+        search: Optional[str] = None,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """List the household's foods, optionally filtered by a search term.
+
+        Use this to resolve an existing Mealie food id+name before building a
+        structured ingredient, instead of hardcoding UUIDs. The Mealie search is
+        token-based; do client-side matching against the returned items if you
+        need fuzzy matching (e.g. "Basmatireis" -> "Reis").
+
+        Args:
+            search: Search term to filter foods by name/alias.
+            page: Page number to retrieve.
+            per_page: Number of items per page.
+
+        Returns:
+            Dict[str, Any]: Foods (under "items") with pagination information.
+        """
+        try:
+            logger.info(
+                {"message": "Fetching foods", "search": search, "per_page": per_page}
+            )
+            return mealie.get_foods(search=search, page=page, per_page=per_page)
+        except Exception as e:
+            error_msg = f"Error fetching foods: {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def create_food(
+        name: str,
+        plural_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a new food.
+
+        Args:
+            name: Name of the food (e.g. "Reis").
+            plural_name: Optional plural name.
+            description: Optional description.
+
+        Returns:
+            Dict[str, Any]: The created food.
+        """
+        try:
+            logger.info({"message": "Creating food", "name": name})
+            return mealie.create_food(
+                name, plural_name=plural_name, description=description
+            )
+        except Exception as e:
+            error_msg = f"Error creating food '{name}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def get_food(food_id: str) -> Dict[str, Any]:
+        """Get a specific food by ID.
+
+        Args:
+            food_id: The UUID of the food.
+
+        Returns:
+            Dict[str, Any]: The food details.
+        """
+        try:
+            logger.info({"message": "Fetching food", "food_id": food_id})
+            return mealie.get_food(food_id)
+        except Exception as e:
+            error_msg = f"Error fetching food '{food_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def update_food(
+        food_id: str,
+        name: Optional[str] = None,
+        plural_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update a food's details (only provided fields are changed).
+
+        Args:
+            food_id: The UUID of the food to update.
+            name: New name for the food.
+            plural_name: New plural name.
+            description: New description.
+
+        Returns:
+            Dict[str, Any]: The updated food.
+        """
+        try:
+            logger.info({"message": "Updating food", "food_id": food_id})
+
+            food_data: Dict[str, Any] = {}
+            if name is not None:
+                food_data["name"] = name
+            if plural_name is not None:
+                food_data["pluralName"] = plural_name
+            if description is not None:
+                food_data["description"] = description
+
+            if not food_data:
+                raise ValueError("At least one field must be provided to update")
+
+            return mealie.update_food(food_id, food_data)
+        except Exception as e:
+            error_msg = f"Error updating food '{food_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def delete_food(food_id: str) -> Dict[str, Any]:
+        """Delete a specific food.
+
+        Args:
+            food_id: The UUID of the food to delete.
+
+        Returns:
+            Dict[str, Any]: Confirmation of deletion.
+        """
+        try:
+            logger.info({"message": "Deleting food", "food_id": food_id})
+            return mealie.delete_food(food_id)
+        except Exception as e:
+            error_msg = f"Error deleting food '{food_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -1,14 +1,107 @@
 import logging
+import re
 import traceback
-from typing import Any, Dict, List, Optional
+import uuid
+from typing import Any, Dict, List, Optional, Union
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 
 from mealie import MealieFetcher
-from models.recipe import Recipe, RecipeIngredient, RecipeInstruction
+from models.recipe import (
+    OrganizerRef,
+    Recipe,
+    RecipeIngredient,
+    RecipeIngredientInput,
+    RecipeInstruction,
+    RecipeInstructionInput,
+    RecipeTag,
+    RecipeTool,
+)
 
 logger = logging.getLogger("mealie-mcp")
+
+
+def _build_ingredient(
+    ingredient: Union[str, RecipeIngredientInput, Dict[str, Any]],
+) -> RecipeIngredient:
+    """Coerce a flat string or structured ingredient into a RecipeIngredient.
+
+    A plain string becomes a note for Mealie's natural-language parser to
+    resolve; a structured object maps its fields straight onto the Mealie
+    RecipeIngredient model.
+    """
+    if isinstance(ingredient, str):
+        return RecipeIngredient(note=ingredient)
+    if isinstance(ingredient, RecipeIngredientInput):
+        ingredient = ingredient.model_dump(exclude_none=True)
+    return RecipeIngredient(**ingredient)
+
+
+def _build_instruction(
+    instruction: Union[str, RecipeInstructionInput, Dict[str, Any]],
+) -> RecipeInstruction:
+    """Coerce a flat string or structured step into a RecipeInstruction."""
+    if isinstance(instruction, str):
+        return RecipeInstruction(text=instruction)
+    if isinstance(instruction, RecipeInstructionInput):
+        instruction = instruction.model_dump(exclude_none=True)
+    return RecipeInstruction(**instruction)
+
+
+_REF_NAMESPACE = uuid.uuid5(
+    uuid.NAMESPACE_URL, "mealie-mcp/recipe-ingredient-reference"
+)
+
+
+def _slugify(name: str) -> str:
+    """Best-effort Mealie-style slug, used to fill an omitted organizer slug."""
+    slug = name.strip().lower()
+    for umlaut, ascii_ in (("ä", "a"), ("ö", "o"), ("ü", "u"), ("ß", "ss")):
+        slug = slug.replace(umlaut, ascii_)
+    return re.sub(r"[^a-z0-9]+", "-", slug).strip("-")
+
+
+def _organizer_payload(org: OrganizerRef) -> Dict[str, Any]:
+    """Map an OrganizerRef to the {id, name, slug} Mealie requires for tags/tools.
+
+    Mealie requires a slug on every tag/tool reference; derive one from the name
+    when the caller omits it (Mealie links the organizer by its id, so the exact
+    slug only needs to be present).
+    """
+    return {"id": org.id, "name": org.name, "slug": org.slug or _slugify(org.name)}
+
+
+def _coerce_reference_id(value: Optional[str]) -> Optional[str]:
+    """Return a UUID v4 string for an ingredient referenceId.
+
+    Mealie validates instruction ingredientReferences as UUID **v4**. An
+    existing v4 UUID passes through unchanged; anything else (a non-UUID, or a
+    UUID of another version) is mapped to a stable v4 UUID derived from it — a
+    uuid5 hash with the version/variant bits forced to 4/RFC-4122. It is
+    deterministic, so the same caller-supplied id used on an ingredient and on
+    an instruction step resolves to the same v4 UUID and keeps the link intact.
+    """
+    if not value:
+        return value
+    try:
+        existing = uuid.UUID(str(value))
+        if existing.version == 4:
+            return str(existing)
+    except (ValueError, AttributeError, TypeError):
+        pass
+    return str(uuid.UUID(int=uuid.uuid5(_REF_NAMESPACE, str(value)).int, version=4))
+
+
+def _normalize_references(recipe: Recipe) -> None:
+    """Coerce every ingredient referenceId and instruction link to a UUID."""
+    for ingredient in recipe.recipeIngredient:
+        if ingredient.referenceId:
+            ingredient.referenceId = _coerce_reference_id(ingredient.referenceId)
+    for step in recipe.recipeInstructions:
+        for ref in step.ingredientReferences:
+            if ref.referenceId:
+                ref.referenceId = _coerce_reference_id(ref.referenceId)
 
 
 def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
@@ -123,6 +216,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                     "recipeYield",
                     "totalTime",
                     "rating",
+                    "orgURL",
+                    "tags",
+                    "tools",
                     "recipeIngredient",
                     "lastMade",
                 },
@@ -138,14 +234,26 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
 
     @mcp.tool()
     def create_recipe(
-        name: str, ingredients: List[str], instructions: List[str]
+        name: str,
+        ingredients: List[Union[str, RecipeIngredientInput]],
+        instructions: List[Union[str, RecipeInstructionInput]],
     ) -> Dict[str, Any]:
-        """Create a new recipe
+        """Create a new recipe.
+
+        Ingredients and instructions each accept either a plain string or a
+        structured object:
+
+        - An ingredient string (e.g. "200 g basmati rice") is resolved by
+          Mealie's natural-language parser into quantity/unit/food.
+        - An ingredient object can set quantity, note, title, an existing
+          Mealie unit/food (by id and name), and a referenceId for step links.
+        - An instruction string is the step text; an instruction object can
+          also carry a title and ingredientReferences for cook-mode highlights.
 
         Args:
             name: The name of the new recipe to be created.
-            ingredients: A list of ingredients for the recipe include quantities and units.
-            instructions: A list of instructions for preparing the recipe.
+            ingredients: Ingredient strings and/or structured ingredient objects.
+            instructions: Instruction strings and/or structured instruction objects.
 
         Returns:
             Dict[str, Any]: The created recipe details.
@@ -155,10 +263,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             slug = mealie.create_recipe(name)
             recipe_json = mealie.get_recipe(slug)
             recipe = Recipe.model_validate(recipe_json)
-            recipe.recipeIngredient = [RecipeIngredient(note=i) for i in ingredients]
-            recipe.recipeInstructions = [
-                RecipeInstruction(text=i) for i in instructions
-            ]
+            recipe.recipeIngredient = [_build_ingredient(i) for i in ingredients]
+            recipe.recipeInstructions = [_build_instruction(i) for i in instructions]
+            _normalize_references(recipe)
             return mealie.update_recipe(slug, recipe.model_dump(exclude_none=True))
         except Exception as e:
             error_msg = f"Error creating recipe '{name}': {str(e)}"
@@ -171,15 +278,18 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
     @mcp.tool()
     def update_recipe(
         slug: str,
-        ingredients: List[str],
-        instructions: List[str],
+        ingredients: List[Union[str, RecipeIngredientInput]],
+        instructions: List[Union[str, RecipeInstructionInput]],
     ) -> Dict[str, Any]:
         """Replaces the ingredients and instructions of an existing recipe.
 
+        Ingredients and instructions accept the same flat-string or structured
+        forms as create_recipe.
+
         Args:
             slug: The unique text identifier for the recipe to be updated.
-            ingredients: A list of ingredients for the recipe include quantities and units.
-            instructions: A list of instructions for preparing the recipe.
+            ingredients: Ingredient strings and/or structured ingredient objects.
+            instructions: Instruction strings and/or structured instruction objects.
 
         Returns:
             Dict[str, Any]: The updated recipe details.
@@ -188,13 +298,108 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             logger.info({"message": "Updating recipe", "slug": slug})
             recipe_json = mealie.get_recipe(slug)
             recipe = Recipe.model_validate(recipe_json)
-            recipe.recipeIngredient = [RecipeIngredient(note=i) for i in ingredients]
-            recipe.recipeInstructions = [
-                RecipeInstruction(text=i) for i in instructions
-            ]
+            recipe.recipeIngredient = [_build_ingredient(i) for i in ingredients]
+            recipe.recipeInstructions = [_build_instruction(i) for i in instructions]
+            _normalize_references(recipe)
             return mealie.update_recipe(slug, recipe.model_dump(exclude_none=True))
         except Exception as e:
             error_msg = f"Error updating recipe '{slug}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def create_recipe_full(
+        name: str,
+        description: Optional[str] = None,
+        org_url: Optional[str] = None,
+        total_time: Optional[str] = None,
+        prep_time: Optional[str] = None,
+        cook_time: Optional[str] = None,
+        perform_time: Optional[str] = None,
+        recipe_yield: Optional[str] = None,
+        servings: Optional[int] = None,
+        image_url: Optional[str] = None,
+        ingredients: Optional[List[Union[str, RecipeIngredientInput]]] = None,
+        instructions: Optional[List[Union[str, RecipeInstructionInput]]] = None,
+        tags: Optional[List[OrganizerRef]] = None,
+        tools: Optional[List[OrganizerRef]] = None,
+    ) -> Dict[str, Any]:
+        """Create a recipe and populate all of its content in one call.
+
+        Use this instead of create_recipe when you already have complete
+        recipe data (description, timing, servings, source URL, ingredients,
+        steps, and optionally an image URL). It creates the recipe, fills in
+        every provided field, and sets the image by scraping image_url when
+        given.
+
+        Ingredients and instructions accept the same flat-string or structured
+        forms as create_recipe.
+
+        Args:
+            name: The name of the new recipe.
+            description: Recipe description.
+            org_url: Source URL for the recipe (shown as a link in the Mealie UI).
+            total_time: Total time as free text, e.g. "35 min" or ISO-8601 "PT35M".
+            prep_time: Preparation time, same format as total_time.
+            cook_time: Cooking time, same format as total_time.
+            perform_time: Hands-on/active time, same format as total_time.
+            recipe_yield: Yield as free text, e.g. "4 Portionen".
+            servings: Number of servings (numeric).
+            image_url: URL of an image to scrape and set as the recipe image.
+            ingredients: Ingredient strings and/or structured ingredient objects.
+            instructions: Instruction strings and/or structured instruction objects.
+            tags: Existing Mealie tags (id+name) to assign; look up with get_tags.
+            tools: Existing Mealie tools (id+name) to assign; look up with get_tools.
+
+        Returns:
+            Dict[str, Any]: The created recipe details.
+        """
+        try:
+            logger.info({"message": "Creating full recipe", "name": name})
+            slug = mealie.create_recipe(name)
+            recipe_json = mealie.get_recipe(slug)
+            recipe = Recipe.model_validate(recipe_json)
+
+            if description is not None:
+                recipe.description = description
+            if org_url is not None:
+                recipe.orgURL = org_url
+            if total_time is not None:
+                recipe.totalTime = total_time
+            if prep_time is not None:
+                recipe.prepTime = prep_time
+            if cook_time is not None:
+                recipe.cookTime = cook_time
+            if perform_time is not None:
+                recipe.performTime = perform_time
+            if recipe_yield is not None:
+                recipe.recipeYield = recipe_yield
+            if servings is not None:
+                recipe.recipeServings = servings
+            if ingredients is not None:
+                recipe.recipeIngredient = [_build_ingredient(i) for i in ingredients]
+            if instructions is not None:
+                recipe.recipeInstructions = [
+                    _build_instruction(i) for i in instructions
+                ]
+            if tags is not None:
+                recipe.tags = [RecipeTag(**_organizer_payload(t)) for t in tags]
+            if tools is not None:
+                recipe.tools = [RecipeTool(**_organizer_payload(t)) for t in tools]
+            _normalize_references(recipe)
+
+            updated = mealie.update_recipe(slug, recipe.model_dump(exclude_none=True))
+
+            if image_url is not None:
+                mealie.scrape_recipe_image_from_url(slug, image_url)
+                updated = mealie.get_recipe(slug)
+
+            return updated
+        except Exception as e:
+            error_msg = f"Error creating full recipe '{name}': {str(e)}"
             logger.error({"message": error_msg})
             logger.debug(
                 {"message": "Error traceback", "traceback": traceback.format_exc()}
@@ -207,16 +412,30 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         name: Optional[str] = None,
         description: Optional[str] = None,
         recipe_yield: Optional[str] = None,
+        servings: Optional[int] = None,
         total_time: Optional[str] = None,
+        prep_time: Optional[str] = None,
+        cook_time: Optional[str] = None,
+        perform_time: Optional[str] = None,
+        org_url: Optional[str] = None,
+        tags: Optional[List[OrganizerRef]] = None,
+        tools: Optional[List[OrganizerRef]] = None,
     ) -> Dict[str, Any]:
         """Partially update a recipe (only updates provided fields).
 
         Args:
             slug: The unique text identifier for the recipe to be updated.
-            name: New name for the recipe (optional)
-            description: New description for the recipe (optional)
-            recipe_yield: New yield/servings for the recipe (optional)
-            total_time: New total time for the recipe (optional)
+            name: New name for the recipe.
+            description: New description for the recipe.
+            recipe_yield: Yield as free text, e.g. "4 Portionen".
+            servings: Number of servings (numeric).
+            total_time: Total time as free text, e.g. "35 min" or ISO-8601 "PT35M".
+            prep_time: Preparation time, same format as total_time.
+            cook_time: Cooking time, same format as total_time.
+            perform_time: Hands-on/active time, same format as total_time.
+            org_url: Source URL for the recipe (shown as a link in the Mealie UI).
+            tags: Existing Mealie tags (id+name) to set; look up with get_tags.
+            tools: Existing Mealie tools (id+name) to set; look up with get_tools.
 
         Returns:
             Dict[str, Any]: The updated recipe details.
@@ -231,8 +450,22 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 recipe_data["description"] = description
             if recipe_yield is not None:
                 recipe_data["recipeYield"] = recipe_yield
+            if servings is not None:
+                recipe_data["recipeServings"] = servings
             if total_time is not None:
                 recipe_data["totalTime"] = total_time
+            if prep_time is not None:
+                recipe_data["prepTime"] = prep_time
+            if cook_time is not None:
+                recipe_data["cookTime"] = cook_time
+            if perform_time is not None:
+                recipe_data["performTime"] = perform_time
+            if org_url is not None:
+                recipe_data["orgURL"] = org_url
+            if tags is not None:
+                recipe_data["tags"] = [_organizer_payload(t) for t in tags]
+            if tools is not None:
+                recipe_data["tools"] = [_organizer_payload(t) for t in tools]
 
             if not recipe_data:
                 raise ValueError("At least one field must be provided to update")
@@ -241,7 +474,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         except Exception as e:
             error_msg = f"Error patching recipe '{slug}': {str(e)}"
             logger.error({"message": error_msg})
-            logger.debug({"message": "Error traceback", "traceback": traceback.format_exc()})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
             raise ToolError(error_msg)
 
     @mcp.tool()
@@ -261,7 +496,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         except Exception as e:
             error_msg = f"Error duplicating recipe '{slug}': {str(e)}"
             logger.error({"message": error_msg})
-            logger.debug({"message": "Error traceback", "traceback": traceback.format_exc()})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
             raise ToolError(error_msg)
 
     @mcp.tool()
@@ -280,7 +517,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         except Exception as e:
             error_msg = f"Error updating recipe last made '{slug}': {str(e)}"
             logger.error({"message": error_msg})
-            logger.debug({"message": "Error traceback", "traceback": traceback.format_exc()})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
             raise ToolError(error_msg)
 
     @mcp.tool()
@@ -295,12 +534,20 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             Dict[str, Any]: Confirmation that the image was set.
         """
         try:
-            logger.info({"message": "Setting recipe image from URL", "slug": slug, "url": image_url})
+            logger.info(
+                {
+                    "message": "Setting recipe image from URL",
+                    "slug": slug,
+                    "url": image_url,
+                }
+            )
             return mealie.scrape_recipe_image_from_url(slug, image_url)
         except Exception as e:
             error_msg = f"Error setting recipe image from URL '{slug}': {str(e)}"
             logger.error({"message": error_msg})
-            logger.debug({"message": "Error traceback", "traceback": traceback.format_exc()})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
             raise ToolError(error_msg)
 
     @mcp.tool()
@@ -317,7 +564,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         try:
             import os
 
-            logger.info({"message": "Uploading recipe image", "slug": slug, "path": image_path})
+            logger.info(
+                {"message": "Uploading recipe image", "slug": slug, "path": image_path}
+            )
 
             if not os.path.exists(image_path):
                 raise ValueError(f"Image file not found: {image_path}")
@@ -330,7 +579,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         except Exception as e:
             error_msg = f"Error uploading recipe image '{slug}': {str(e)}"
             logger.error({"message": error_msg})
-            logger.debug({"message": "Error traceback", "traceback": traceback.format_exc()})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
             raise ToolError(error_msg)
 
     @mcp.tool()
@@ -347,7 +598,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         try:
             import os
 
-            logger.info({"message": "Uploading recipe asset", "slug": slug, "path": asset_path})
+            logger.info(
+                {"message": "Uploading recipe asset", "slug": slug, "path": asset_path}
+            )
 
             if not os.path.exists(asset_path):
                 raise ValueError(f"Asset file not found: {asset_path}")
@@ -360,7 +613,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         except Exception as e:
             error_msg = f"Error uploading recipe asset '{slug}': {str(e)}"
             logger.error({"message": error_msg})
-            logger.debug({"message": "Error traceback", "traceback": traceback.format_exc()})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
             raise ToolError(error_msg)
 
     @mcp.tool()
@@ -379,5 +634,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         except Exception as e:
             error_msg = f"Error deleting recipe '{slug}': {str(e)}"
             logger.error({"message": error_msg})
-            logger.debug({"message": "Error traceback", "traceback": traceback.format_exc()})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
             raise ToolError(error_msg)

--- a/src/tools/tools_tools.py
+++ b/src/tools/tools_tools.py
@@ -1,0 +1,165 @@
+import logging
+import traceback
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from mealie import MealieFetcher
+
+logger = logging.getLogger("mealie-mcp")
+
+
+def register_tools_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
+    """Register all recipe-tool (kitchen equipment) tools with the MCP server."""
+
+    @mcp.tool()
+    def get_tools(
+        search: Optional[str] = None,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """List the household's recipe tools, optionally filtered by a search term.
+
+        Use this to resolve a tool id+name before assigning it to a recipe via
+        create_recipe_full or patch_recipe. Each item includes
+        ``householdsWithTool``: a non-empty value means the household owns the
+        tool, an empty list means it only exists in the database.
+
+        Args:
+            search: Search term to filter tools by name.
+            page: Page number to retrieve.
+            per_page: Number of items per page.
+
+        Returns:
+            Dict[str, Any]: Tools (under "items") with pagination information.
+        """
+        try:
+            logger.info(
+                {"message": "Fetching tools", "search": search, "per_page": per_page}
+            )
+            return mealie.get_tools(search=search, page=page, per_page=per_page)
+        except Exception as e:
+            error_msg = f"Error fetching tools: {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def create_tool(name: str) -> Dict[str, Any]:
+        """Create a new recipe tool.
+
+        Args:
+            name: Name of the tool (e.g. "Kochtopf", "Backofen").
+
+        Returns:
+            Dict[str, Any]: The created tool.
+        """
+        try:
+            logger.info({"message": "Creating tool", "name": name})
+            return mealie.create_tool(name)
+        except Exception as e:
+            error_msg = f"Error creating tool '{name}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def get_tool(tool_id: str) -> Dict[str, Any]:
+        """Get a specific tool by ID.
+
+        Args:
+            tool_id: The UUID of the tool.
+
+        Returns:
+            Dict[str, Any]: The tool details.
+        """
+        try:
+            logger.info({"message": "Fetching tool", "tool_id": tool_id})
+            return mealie.get_tool(tool_id)
+        except Exception as e:
+            error_msg = f"Error fetching tool '{tool_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def get_tool_by_slug(tool_slug: str) -> Dict[str, Any]:
+        """Get a specific tool by its slug.
+
+        Args:
+            tool_slug: The slug of the tool (e.g. "kochtopf").
+
+        Returns:
+            Dict[str, Any]: The tool details.
+        """
+        try:
+            logger.info({"message": "Fetching tool by slug", "tool_slug": tool_slug})
+            return mealie.get_tool_by_slug(tool_slug)
+        except Exception as e:
+            error_msg = f"Error fetching tool by slug '{tool_slug}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def update_tool(
+        tool_id: str,
+        name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update a tool's details (only provided fields are changed).
+
+        Args:
+            tool_id: The UUID of the tool to update.
+            name: New name for the tool.
+
+        Returns:
+            Dict[str, Any]: The updated tool.
+        """
+        try:
+            logger.info({"message": "Updating tool", "tool_id": tool_id})
+
+            tool_data: Dict[str, Any] = {}
+            if name is not None:
+                tool_data["name"] = name
+
+            if not tool_data:
+                raise ValueError("At least one field must be provided to update")
+
+            return mealie.update_tool(tool_id, tool_data)
+        except Exception as e:
+            error_msg = f"Error updating tool '{tool_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def delete_tool(tool_id: str) -> Dict[str, Any]:
+        """Delete a specific tool.
+
+        Args:
+            tool_id: The UUID of the tool to delete.
+
+        Returns:
+            Dict[str, Any]: Confirmation of deletion.
+        """
+        try:
+            logger.info({"message": "Deleting tool", "tool_id": tool_id})
+            return mealie.delete_tool(tool_id)
+        except Exception as e:
+            error_msg = f"Error deleting tool '{tool_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)

--- a/src/tools/units_tools.py
+++ b/src/tools/units_tools.py
@@ -1,0 +1,167 @@
+import logging
+import traceback
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from mealie import MealieFetcher
+
+logger = logging.getLogger("mealie-mcp")
+
+
+def register_units_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
+    """Register all unit-related tools with the MCP server."""
+
+    @mcp.tool()
+    def get_units(
+        search: Optional[str] = None,
+        page: Optional[int] = None,
+        per_page: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """List the household's units, optionally filtered by a search term.
+
+        Use this to resolve an existing Mealie unit id+name before building a
+        structured ingredient.
+
+        Args:
+            search: Search term to filter units by name/abbreviation.
+            page: Page number to retrieve.
+            per_page: Number of items per page.
+
+        Returns:
+            Dict[str, Any]: Units (under "items") with pagination information.
+        """
+        try:
+            logger.info(
+                {"message": "Fetching units", "search": search, "per_page": per_page}
+            )
+            return mealie.get_units(search=search, page=page, per_page=per_page)
+        except Exception as e:
+            error_msg = f"Error fetching units: {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def create_unit(
+        name: str,
+        abbreviation: Optional[str] = None,
+        plural_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Create a new unit.
+
+        Args:
+            name: Name of the unit (e.g. "Gramm").
+            abbreviation: Optional short form (e.g. "g", "ml").
+            plural_name: Optional plural name.
+            description: Optional description.
+
+        Returns:
+            Dict[str, Any]: The created unit.
+        """
+        try:
+            logger.info({"message": "Creating unit", "name": name})
+            return mealie.create_unit(
+                name,
+                abbreviation=abbreviation,
+                plural_name=plural_name,
+                description=description,
+            )
+        except Exception as e:
+            error_msg = f"Error creating unit '{name}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def get_unit(unit_id: str) -> Dict[str, Any]:
+        """Get a specific unit by ID.
+
+        Args:
+            unit_id: The UUID of the unit.
+
+        Returns:
+            Dict[str, Any]: The unit details.
+        """
+        try:
+            logger.info({"message": "Fetching unit", "unit_id": unit_id})
+            return mealie.get_unit(unit_id)
+        except Exception as e:
+            error_msg = f"Error fetching unit '{unit_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def update_unit(
+        unit_id: str,
+        name: Optional[str] = None,
+        abbreviation: Optional[str] = None,
+        plural_name: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update a unit's details (only provided fields are changed).
+
+        Args:
+            unit_id: The UUID of the unit to update.
+            name: New name for the unit.
+            abbreviation: New abbreviation.
+            plural_name: New plural name.
+            description: New description.
+
+        Returns:
+            Dict[str, Any]: The updated unit.
+        """
+        try:
+            logger.info({"message": "Updating unit", "unit_id": unit_id})
+
+            unit_data: Dict[str, Any] = {}
+            if name is not None:
+                unit_data["name"] = name
+            if abbreviation is not None:
+                unit_data["abbreviation"] = abbreviation
+            if plural_name is not None:
+                unit_data["pluralName"] = plural_name
+            if description is not None:
+                unit_data["description"] = description
+
+            if not unit_data:
+                raise ValueError("At least one field must be provided to update")
+
+            return mealie.update_unit(unit_id, unit_data)
+        except Exception as e:
+            error_msg = f"Error updating unit '{unit_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def delete_unit(unit_id: str) -> Dict[str, Any]:
+        """Delete a specific unit.
+
+        Args:
+            unit_id: The UUID of the unit to delete.
+
+        Returns:
+            Dict[str, Any]: Confirmation of deletion.
+        """
+        try:
+            logger.info({"message": "Deleting unit", "unit_id": unit_id})
+            return mealie.delete_unit(unit_id)
+        except Exception as e:
+            error_msg = f"Error deleting unit '{unit_id}': {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,150 @@
+"""Shared test fixtures.
+
+Tests exercise the MCP tools end-to-end against a fake Mealie client that
+records the HTTP requests the mixins would make (method, url, json, params)
+and returns canned responses. No network access is required.
+"""
+
+import os
+import sys
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from mealie import MealieFetcher  # noqa: E402
+from tools import register_all_tools  # noqa: E402
+
+# A minimal but schema-valid recipe payload (satisfies the required Recipe
+# fields), used as the response to GET /api/recipes/<slug>.
+BASE_RECIPE = {
+    "id": "00000000-0000-0000-0000-000000000000",
+    "userId": "11111111-1111-1111-1111-111111111111",
+    "householdId": "22222222-2222-2222-2222-222222222222",
+    "groupId": "33333333-3333-3333-3333-333333333333",
+    "name": "Test Recipe",
+    "slug": "test-recipe",
+    "dateAdded": "2024-01-01",
+    "dateUpdated": "2024-01-01T00:00:00",
+    "createdAt": "2024-01-01T00:00:00",
+    "updatedAt": "2024-01-01T00:00:00",
+}
+
+
+class FakeFetcher(MealieFetcher):
+    """MealieFetcher with the network layer replaced by a recorder.
+
+    Skips MealieClient.__init__ (no connection) and overrides _handle_request
+    so the real mixin methods run and we can assert on the requests they build.
+    """
+
+    def __init__(self):
+        self.requests = []
+        self.created_slug = "test-recipe"
+        self.recipe = dict(BASE_RECIPE)
+
+    def _handle_request(self, method, url, **kwargs):
+        self.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "json": kwargs.get("json"),
+                "params": kwargs.get("params"),
+            }
+        )
+        if method == "POST" and url == "/api/recipes":
+            name = (kwargs.get("json") or {}).get("name")
+            if name:
+                # reflect the created name on subsequent GET (like the real API)
+                self.recipe = {**self.recipe, "name": name, "slug": self.created_slug}
+            return self.created_slug
+        if method == "GET" and url.startswith("/api/recipes/") and url.count("/") == 3:
+            return dict(self.recipe)
+        if method in ("PUT", "PATCH") and url.startswith("/api/recipes/"):
+            return kwargs.get("json", {})
+        # single-record GET (the fetch-merge update path reads the existing record)
+        if method == "GET" and (
+            url.startswith("/api/foods/")
+            or url.startswith("/api/units/")
+            or url.startswith("/api/organizers/tools/")
+        ):
+            return {
+                "id": url.rsplit("/", 1)[-1],
+                "name": "Existing",
+                "pluralName": "Existings",
+                "description": "old",
+            }
+        # list endpoints
+        if method == "GET" and url in (
+            "/api/foods",
+            "/api/units",
+            "/api/organizers/tools",
+        ):
+            return {
+                "items": [{"id": "x1", "name": "Sample"}],
+                "page": 1,
+                "perPage": 50,
+                "total": 1,
+            }
+        # create echoes the body with a generated id
+        if method == "POST" and url in (
+            "/api/foods",
+            "/api/units",
+            "/api/organizers/tools",
+        ):
+            return {**(kwargs.get("json") or {}), "id": "generated-0001"}
+        # full-replace update echoes the merged body
+        if method == "PUT" and (
+            url.startswith("/api/foods/")
+            or url.startswith("/api/units/")
+            or url.startswith("/api/organizers/tools/")
+        ):
+            return kwargs.get("json", {})
+        # delete (Mealie normalizes the empty body to a success payload)
+        if method == "DELETE":
+            return {"success": True, "message": "Operation completed successfully"}
+        return {"ok": True}
+
+    def last(self, method=None, url_contains=None):
+        """Return the most recent recorded request matching method/url filter."""
+        for req in reversed(self.requests):
+            if method is not None and req["method"] != method:
+                continue
+            if url_contains is not None and url_contains not in req["url"]:
+                continue
+            return req
+        return None
+
+
+@pytest.fixture
+def fetcher():
+    return FakeFetcher()
+
+
+@pytest.fixture
+def server(fetcher):
+    mcp = FastMCP("test")
+    register_all_tools(mcp, fetcher)
+    return mcp, fetcher
+
+
+@pytest.fixture
+def invoke(server):
+    """Async helper: call a tool by name with kwargs, return its parsed result."""
+    import json
+
+    mcp, _ = server
+
+    async def _invoke(tool_name, /, **arguments):
+        result = await mcp.call_tool(tool_name, arguments)
+        content, structured = result if isinstance(result, tuple) else (result, None)
+        if isinstance(structured, dict) and set(structured.keys()) == {"result"}:
+            return structured["result"]
+        if structured is not None:
+            return structured
+        if content and getattr(content[0], "text", None):
+            return json.loads(content[0].text)
+        return content
+
+    return _invoke

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,75 @@
+"""Regression tests for the 2026-06-03 live E2E bug report (BUG-1/2/3)."""
+
+import uuid
+
+# --- BUG-1: update_* must fetch-merge so id/name stay in the PUT body -------
+
+
+async def test_update_food_fetch_merges_and_keeps_id(invoke, fetcher):
+    await invoke("update_food", food_id="food-1", description="new desc")
+    put = fetcher.last("PUT", "/api/foods/food-1")["json"]
+    assert put["id"] == "food-1"  # required by Mealie; was null before the fix
+    assert put["name"] == "Existing"  # preserved (full-replace would null it)
+    assert put["pluralName"] == "Existings"  # preserved
+    assert put["description"] == "new desc"  # applied
+
+
+async def test_update_tool_fetch_merges_and_keeps_id(invoke, fetcher):
+    await invoke("update_tool", tool_id="k1", name="Topf")
+    put = fetcher.last("PUT", "/api/organizers/tools/k1")["json"]
+    assert put["id"] == "k1"
+    assert put["name"] == "Topf"  # applied
+    assert put["description"] == "old"  # preserved
+
+
+# --- BUG-2: tags/tools need a slug; derive one when the caller omits it -----
+
+
+async def test_create_recipe_full_fills_organizer_slug(invoke, fetcher):
+    await invoke(
+        "create_recipe_full",
+        name="R",
+        tags=[{"id": "t1", "name": "Vegetarisch"}],  # slug omitted -> derived
+        tools=[{"id": "k1", "name": "Pfanne", "slug": "my-pfanne"}],  # slug kept
+    )
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    assert body["tags"][0] == {"id": "t1", "name": "Vegetarisch", "slug": "vegetarisch"}
+    assert body["tools"][0]["slug"] == "my-pfanne"
+
+
+async def test_patch_recipe_fills_organizer_slug_with_umlaut(invoke, fetcher):
+    await invoke("patch_recipe", slug="r", tags=[{"id": "t1", "name": "Feta-Käse"}])
+    body = fetcher.last("PATCH", "/api/recipes/")["json"]
+    assert body["tags"][0]["slug"] == "feta-kase"  # ä transliterated, hyphenated
+
+
+# --- BUG-3: non-UUID referenceId is coerced to a stable UUID, link intact ---
+
+
+async def test_reference_id_coerced_and_link_preserved(invoke, fetcher):
+    await invoke(
+        "create_recipe",
+        name="R",
+        ingredients=[{"note": "2 eggs", "referenceId": "ing-1"}],
+        instructions=[
+            {"text": "Fry", "ingredientReferences": [{"referenceId": "ing-1"}]}
+        ],
+    )
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    ing_ref = body["recipeIngredient"][0]["referenceId"]
+    step_ref = body["recipeInstructions"][0]["ingredientReferences"][0]["referenceId"]
+    assert uuid.UUID(ing_ref).version == 4  # Mealie requires UUID v4
+    assert ing_ref == step_ref  # same source id -> same UUID, link preserved
+    assert ing_ref != "ing-1"
+
+
+async def test_reference_id_valid_uuid_passes_through(invoke, fetcher):
+    valid = "a1000001-0000-4000-8000-000000000001"  # already a v4 UUID
+    await invoke(
+        "create_recipe",
+        name="R",
+        ingredients=[{"note": "x", "referenceId": valid}],
+        instructions=["step"],
+    )
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    assert body["recipeIngredient"][0]["referenceId"] == valid

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,86 @@
+"""Tests for the Pydantic recipe models, including the typing fixes."""
+
+from conftest import BASE_RECIPE
+
+from models.recipe import (
+    OrganizerRef,
+    Recipe,
+    RecipeIngredientInput,
+    RecipeInstructionInput,
+)
+
+
+def test_time_fields_accept_text():
+    # Previously typed as int, which raised on textual times returned by Mealie.
+    r = Recipe.model_validate(
+        {
+            **BASE_RECIPE,
+            "totalTime": "35 Minutes",
+            "prepTime": "10 min",
+            "cookTime": "PT25M",
+            "performTime": "20 Minuten",
+        }
+    )
+    assert r.totalTime == "35 Minutes"
+    assert r.cookTime == "PT25M"
+    assert r.performTime == "20 Minuten"
+
+
+def test_instruction_ingredient_references_are_objects():
+    r = Recipe.model_validate(
+        {
+            **BASE_RECIPE,
+            "recipeInstructions": [
+                {"text": "Mix", "ingredientReferences": [{"referenceId": "abc"}]}
+            ],
+        }
+    )
+    assert r.recipeInstructions[0].ingredientReferences[0].referenceId == "abc"
+
+
+def test_tags_tools_categories_are_objects():
+    # Previously typed as list[str]; Mealie returns objects.
+    r = Recipe.model_validate(
+        {
+            **BASE_RECIPE,
+            "tags": [{"id": "t1", "name": "Quick", "slug": "quick"}],
+            "tools": [
+                {
+                    "id": "k1",
+                    "name": "Pfanne",
+                    "slug": "pfanne",
+                    "householdsWithTool": ["h1"],
+                }
+            ],
+            "recipeCategory": [{"id": "c1", "name": "Dinner", "slug": "dinner"}],
+        }
+    )
+    assert r.tags[0].name == "Quick"
+    assert r.tools[0].householdsWithTool == ["h1"]
+    assert r.recipeCategory[0].slug == "dinner"
+
+
+def test_recipe_ingredient_input_serialisation():
+    ing = RecipeIngredientInput(
+        quantity=2,
+        food={"id": "f1", "name": "egg"},
+        unit={"id": "u1", "name": "piece"},
+        note="large",
+        title="Eggs",
+        referenceId="r1",
+    )
+    dumped = ing.model_dump(exclude_none=True)
+    assert dumped["food"] == {"id": "f1", "name": "egg"}
+    assert dumped["referenceId"] == "r1"
+
+
+def test_recipe_instruction_input_serialisation():
+    step = RecipeInstructionInput(
+        text="Do it", title="Step", ingredientReferences=[{"referenceId": "r1"}]
+    )
+    assert step.ingredientReferences[0].referenceId == "r1"
+
+
+def test_organizer_ref_requires_id_and_name():
+    org = OrganizerRef(id="t1", name="Quick")
+    assert org.model_dump(exclude_none=True) == {"id": "t1", "name": "Quick"}

--- a/tests/test_organizer_tools.py
+++ b/tests/test_organizer_tools.py
@@ -1,0 +1,126 @@
+"""Tests for the foods/units/tools lookup + CRUD tools.
+
+These assert the REST method, path, and payload each tool builds.
+"""
+
+import pytest
+
+# --- Foods ---------------------------------------------------------------
+
+
+async def test_get_foods_forwards_search_and_pagination(invoke, fetcher):
+    await invoke("get_foods", search="Reis", per_page=10)
+    req = fetcher.last("GET", "/api/foods")
+    assert req["params"] == {"search": "Reis", "perPage": 10}
+
+
+async def test_create_food(invoke, fetcher):
+    await invoke("create_food", name="Reis", plural_name="Reissorten")
+    req = fetcher.last("POST", "/api/foods")
+    assert req["json"] == {"name": "Reis", "pluralName": "Reissorten"}
+
+
+async def test_get_food_by_id(invoke, fetcher):
+    await invoke("get_food", food_id="f1")
+    assert fetcher.last("GET", "/api/foods/f1") is not None
+
+
+async def test_update_food(invoke, fetcher):
+    await invoke("update_food", food_id="f1", description="grain")
+    req = fetcher.last("PUT", "/api/foods/f1")
+    # fetch-merge: id kept, change applied (see test_bugfixes for full merge)
+    assert req["json"]["id"] == "f1"
+    assert req["json"]["description"] == "grain"
+
+
+async def test_delete_food(invoke, fetcher):
+    await invoke("delete_food", food_id="f1")
+    assert fetcher.last("DELETE", "/api/foods/f1") is not None
+
+
+# --- Units ---------------------------------------------------------------
+
+
+async def test_get_units(invoke, fetcher):
+    await invoke("get_units", search="Gramm")
+    req = fetcher.last("GET", "/api/units")
+    assert req["params"] == {"search": "Gramm"}
+
+
+async def test_create_unit(invoke, fetcher):
+    await invoke("create_unit", name="Gramm", abbreviation="g")
+    req = fetcher.last("POST", "/api/units")
+    assert req["json"] == {"name": "Gramm", "abbreviation": "g"}
+
+
+async def test_update_unit(invoke, fetcher):
+    await invoke("update_unit", unit_id="u1", abbreviation="ml")
+    req = fetcher.last("PUT", "/api/units/u1")
+    assert req["json"]["id"] == "u1"
+    assert req["json"]["abbreviation"] == "ml"
+
+
+async def test_delete_unit(invoke, fetcher):
+    await invoke("delete_unit", unit_id="u1")
+    assert fetcher.last("DELETE", "/api/units/u1") is not None
+
+
+# --- Tools ---------------------------------------------------------------
+
+
+async def test_get_tools(invoke, fetcher):
+    await invoke("get_tools", search="Pfanne")
+    req = fetcher.last("GET", "/api/organizers/tools")
+    assert req["params"] == {"search": "Pfanne"}
+
+
+async def test_create_tool(invoke, fetcher):
+    await invoke("create_tool", name="Kochtopf")
+    req = fetcher.last("POST", "/api/organizers/tools")
+    assert req["json"] == {"name": "Kochtopf"}
+
+
+async def test_get_tool_by_id_and_slug(invoke, fetcher):
+    await invoke("get_tool", tool_id="k1")
+    assert fetcher.last("GET", "/api/organizers/tools/k1") is not None
+    await invoke("get_tool_by_slug", tool_slug="kochtopf")
+    assert fetcher.last("GET", "/api/organizers/tools/slug/kochtopf") is not None
+
+
+async def test_update_tool(invoke, fetcher):
+    await invoke("update_tool", tool_id="k1", name="Topf")
+    req = fetcher.last("PUT", "/api/organizers/tools/k1")
+    assert req["json"]["id"] == "k1"
+    assert req["json"]["name"] == "Topf"
+
+
+async def test_delete_tool(invoke, fetcher):
+    await invoke("delete_tool", tool_id="k1")
+    assert fetcher.last("DELETE", "/api/organizers/tools/k1") is not None
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    [
+        "get_foods",
+        "create_food",
+        "get_food",
+        "update_food",
+        "delete_food",
+        "get_units",
+        "create_unit",
+        "get_unit",
+        "update_unit",
+        "delete_unit",
+        "get_tools",
+        "create_tool",
+        "get_tool",
+        "get_tool_by_slug",
+        "update_tool",
+        "delete_tool",
+    ],
+)
+async def test_tool_is_registered(server, tool_name):
+    mcp, _ = server
+    names = {t.name for t in await mcp.list_tools()}
+    assert tool_name in names

--- a/tests/test_positive.py
+++ b/tests/test_positive.py
@@ -1,0 +1,79 @@
+"""Positive / happy-path tests: tools succeed on valid input and return
+sensible results (complements the request-shape and regression tests)."""
+
+import pytest
+
+
+@pytest.mark.parametrize("tool", ["get_foods", "get_units", "get_tools"])
+async def test_lookups_return_items(invoke, tool):
+    out = await invoke(tool, search="x")
+    assert isinstance(out, dict)
+    assert "items" in out and isinstance(out["items"], list)
+
+
+async def test_food_crud_roundtrip(invoke):
+    created = await invoke("create_food", name="Reis", plural_name="Reissorten")
+    assert created["id"]
+    got = await invoke("get_food", food_id="f1")
+    assert got["id"] == "f1"
+    updated = await invoke("update_food", food_id="f1", description="grain")
+    assert updated["id"] == "f1"
+    assert updated["description"] == "grain"
+    assert updated["name"] == "Existing"  # untouched field preserved
+    deleted = await invoke("delete_food", food_id="f1")
+    assert deleted.get("success") is True
+
+
+async def test_unit_and_tool_create_return_id(invoke):
+    unit = await invoke("create_unit", name="Gramm", abbreviation="g")
+    assert unit["id"] and unit["name"] == "Gramm"
+    tool = await invoke("create_tool", name="Kochtopf")
+    assert tool["id"] and tool["name"] == "Kochtopf"
+    assert (await invoke("delete_tool", tool_id="k1")).get("success") is True
+
+
+async def test_create_recipe_returns_populated_recipe(invoke):
+    out = await invoke(
+        "create_recipe",
+        name="Happy",
+        ingredients=["200 g rice"],
+        instructions=["Boil it."],
+    )
+    assert out["recipeIngredient"][0]["note"] == "200 g rice"
+    assert out["recipeInstructions"][0]["text"] == "Boil it."
+
+
+async def test_create_recipe_full_returns_full_recipe(invoke):
+    out = await invoke(
+        "create_recipe_full",
+        name="Full Happy",
+        description="a dish",
+        org_url="https://example.com/r",
+        total_time="30 min",
+        recipe_yield="2 Portionen",
+        servings=2,
+        ingredients=["1 onion"],
+        instructions=["Chop."],
+        tags=[{"id": "t1", "name": "Quick"}],
+        tools=[{"id": "k1", "name": "Pfanne"}],
+    )
+    assert out["name"] == "Full Happy"
+    assert out["orgURL"] == "https://example.com/r"
+    assert out["totalTime"] == "30 min"
+    assert out["recipeServings"] == 2
+    assert out["tags"][0]["slug"] == "quick"
+    assert out["tools"][0]["name"] == "Pfanne"
+
+
+async def test_patch_recipe_returns_updated_fields(invoke):
+    out = await invoke("patch_recipe", slug="r", servings=4, prep_time="10 min")
+    assert out["recipeServings"] == 4
+    assert out["prepTime"] == "10 min"
+
+
+async def test_get_recipe_concise_returns_summary(invoke, fetcher):
+    fetcher.recipe = {**fetcher.recipe, "totalTime": "35 min"}
+    out = await invoke("get_recipe_concise", slug="test-recipe")
+    assert out["name"]
+    assert out["slug"]
+    assert out["totalTime"] == "35 min"

--- a/tests/test_recipe_tools.py
+++ b/tests/test_recipe_tools.py
@@ -1,0 +1,122 @@
+"""Tests for the recipe-authoring tools (structured ingredients, full create,
+patch fields, concise output)."""
+
+
+async def test_create_recipe_accepts_flat_and_structured(invoke, fetcher):
+    await invoke(
+        "create_recipe",
+        name="Mixed",
+        ingredients=[
+            "200 g basmati rice",
+            {
+                "quantity": 2,
+                "food": {"id": "f1", "name": "egg"},
+                "note": "large",
+                "referenceId": "a1000001-0000-4000-8000-000000000001",
+            },
+        ],
+        instructions=[
+            "Boil the rice.",
+            {
+                "text": "Fry the eggs.",
+                "title": "Eggs",
+                "ingredientReferences": [
+                    {"referenceId": "a1000001-0000-4000-8000-000000000001"}
+                ],
+            },
+        ],
+    )
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    ings = body["recipeIngredient"]
+    steps = body["recipeInstructions"]
+
+    assert ings[0]["note"] == "200 g basmati rice"
+    assert ings[1]["quantity"] == 2
+    assert ings[1]["food"] == {
+        "id": "f1",
+        "name": "egg",
+        "description": "",
+        "aliases": [],
+        "householdsWithIngredientFood": [],
+    }
+    # already a valid UUID -> passes through unchanged
+    assert ings[1]["referenceId"] == "a1000001-0000-4000-8000-000000000001"
+    assert steps[0]["ingredientReferences"] == []
+    assert steps[1]["title"] == "Eggs"
+    assert steps[1]["ingredientReferences"] == [
+        {"referenceId": "a1000001-0000-4000-8000-000000000001"}
+    ]
+
+
+async def test_create_recipe_full_sets_metadata_tags_tools_and_image(invoke, fetcher):
+    await invoke(
+        "create_recipe_full",
+        name="Full",
+        description="A dish",
+        org_url="https://example.com/r",
+        total_time="30 min",
+        prep_time="10 min",
+        recipe_yield="4 Portionen",
+        servings=2,
+        image_url="https://example.com/img.jpg",
+        ingredients=["1 onion"],
+        instructions=["Chop the onion."],
+        tags=[{"id": "t1", "name": "Quick"}],
+        tools=[{"id": "k1", "name": "Pfanne"}],
+    )
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    assert body["description"] == "A dish"
+    assert body["orgURL"] == "https://example.com/r"
+    assert body["totalTime"] == "30 min"
+    assert body["recipeServings"] == 2
+    assert body["recipeYield"] == "4 Portionen"
+    assert body["recipeIngredient"][0]["note"] == "1 onion"
+    # slug derived from the name (Mealie requires it on organizer refs)
+    assert body["tags"] == [{"id": "t1", "name": "Quick", "slug": "quick"}]
+    assert body["tools"][0]["id"] == "k1"
+    assert body["tools"][0]["slug"] == "pfanne"
+    # image is scraped server-side after the recipe content is written
+    assert fetcher.last("POST", "/image") is not None
+
+
+async def test_patch_recipe_maps_all_fields(invoke, fetcher):
+    await invoke(
+        "patch_recipe",
+        slug="test-recipe",
+        total_time="35 min",
+        prep_time="10 min",
+        cook_time="25 min",
+        perform_time="20 min",
+        servings=4,
+        org_url="https://example.com/r",
+        recipe_yield="4 Portionen",
+        tags=[{"id": "t1", "name": "Quick"}],
+        tools=[{"id": "k1", "name": "Pfanne"}],
+    )
+    body = fetcher.last("PATCH", "/api/recipes/")["json"]
+    assert body == {
+        "recipeYield": "4 Portionen",
+        "recipeServings": 4,
+        "totalTime": "35 min",
+        "prepTime": "10 min",
+        "cookTime": "25 min",
+        "performTime": "20 min",
+        "orgURL": "https://example.com/r",
+        "tags": [{"id": "t1", "name": "Quick", "slug": "quick"}],
+        "tools": [{"id": "k1", "name": "Pfanne", "slug": "pfanne"}],
+    }
+
+
+async def test_get_recipe_concise_includes_orgurl_tags_tools(invoke, fetcher):
+    fetcher.recipe = {
+        **fetcher.recipe,
+        "orgURL": "https://example.com/r",
+        "tags": [{"id": "t1", "name": "Quick", "slug": "quick"}],
+        "tools": [
+            {"id": "k1", "name": "Pfanne", "slug": "pfanne", "householdsWithTool": []}
+        ],
+    }
+    out = await invoke("get_recipe_concise", slug="test-recipe")
+    assert out["orgURL"] == "https://example.com/r"
+    assert out["tags"] == [{"id": "t1", "name": "Quick", "slug": "quick"}]
+    assert out["tools"][0]["name"] == "Pfanne"


### PR DESCRIPTION
## Summary
Adds richer recipe authoring, full foods/units/tools management, and several
fixes that align the models with what the Mealie API actually returns/accepts.
Backwards compatible; covered by a new offline test suite.

## New tools & capabilities
- **Structured ingredients & step links** — `create_recipe` / `update_recipe`
  accept, per item, either a flat string (parsed by Mealie's NLP, as before) or
  a structured object (`quantity`, `unit`, `food`, `note`, `title`,
  `referenceId`). Instruction steps accept `ingredientReferences` for cook-mode
  highlighting. `referenceId` may be any string; it's mapped to a stable
  **UUID v4** (which Mealie's `ingredientReferences` validator requires) and the
  same value reused on a step keeps the ingredient↔step link.
- **`create_recipe_full`** — create and fully populate a recipe (description,
  timing, servings, source URL, ingredients, steps, image, tags, tools) in one
  call.
- **`patch_recipe`** — adds `org_url`, `prep_time`, `cook_time`, `perform_time`,
  `servings`, `tags`, `tools`. Tag/tool refs derive the `slug` Mealie requires
  when it's omitted (organizers are linked by id).
- **Foods / Units / Tools** — full CRUD: `get_*` (list/search), `create_*`,
  `get_*` by id (+ `get_tool_by_slug`), `update_*`, `delete_*`. `get_tools`
  surfaces `householdsWithTool`.
- **`get_recipe_concise`** — also returns `orgURL`, `tags`, and `tools`.

## Fixes (model ↔ Mealie API correctness)
- `Recipe.totalTime` / `prepTime` / `cookTime` / `performTime` typed `str`
  (were `int`; Mealie returns strings like `"30 Minutes"` / `"PT35M"`, which
  previously raised `Input should be a valid integer` in `get_recipe_concise`,
  `create_recipe`, and `update_recipe`).
- `RecipeInstruction.ingredientReferences` and `Recipe.tags` / `tools` /
  `recipeCategory` typed as objects (were `list[str]`; the API uses objects).
- `update_food` / `update_unit` / `update_tool` fetch-merge the existing record
  before Mealie's full-replace `PUT`, so the required `id`/`name` stay populated
  and unset fields are preserved (previously sent a partial body → `NOT NULL`
  failure / field loss).

## Tests
New offline `pytest` suite (`tests/`) running against a fake client that records
the HTTP requests the mixins build — request shapes, the fixes above, and
happy-path coverage. Adds `pytest`/`pytest-asyncio` to the `dev` extra.

## Compatibility
No breaking changes — existing flat-string `create_recipe`/`update_recipe`
calls and the previous `patch_recipe` fields are unchanged.
