### PR TITLE
fix: send name, icon, and extension with recipe asset upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `upload_recipe_asset_file` takes optional `name` and `icon` arguments to
+  override the defaults.
+
+### Fixed
+
+- `upload_recipe_asset_file` failed with a 422 on every call. `POST
+  /api/recipes/{slug}/assets` requires `name`, `icon`, and `extension` in the
+  multipart body alongside the file, and only the file was sent. The extension
+  is derived from the filename, the name defaults to the filename stem, and the
+  icon defaults to `mdi-file`, matching the Mealie web UI. A filename without an
+  extension is now rejected before the request rather than returning a 400.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Restart Claude Desktop to load the server.
 - `mark_recipe_last_made` - Update last made timestamp
 - `set_recipe_image_from_url` - Set image from URL
 - `upload_recipe_image_file` - Upload image file
-- `upload_recipe_asset_file` - Upload document/asset
+- `upload_recipe_asset_file` - Upload document/asset (optional display name and mdi icon)
 - `delete_recipe` - Delete recipe
 
 ### Shopping List Tools (14 operations)

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -80,6 +80,17 @@ And these instructions:
 "Update the yield of the soup recipe to '6 servings'"
 ```
 
+### Recipe Assets
+
+**Attach the source document:**
+```
+"Attach /Users/me/Scans/braise-notes.pdf to the short rib recipe"
+"Attach that PDF as 'Original scan' with the mdi-file-pdf-box icon"
+```
+
+Mealie accepts a fixed set of extensions and derives the stored filename from
+the display name.
+
 ### Recipe Images
 
 **From URL:**

--- a/src/mealie/recipe.py
+++ b/src/mealie/recipe.py
@@ -308,13 +308,26 @@ class RecipeMixin:
         logger.info({"message": "Uploading recipe image", "slug": slug, "filename": filename})
         return self._handle_request("PUT", f"/api/recipes/{slug}/image", files=files)
 
-    def upload_recipe_asset(self, slug: str, asset_data: bytes, filename: str) -> Dict[str, Any]:
+    def upload_recipe_asset(
+        self,
+        slug: str,
+        asset_data: bytes,
+        filename: str,
+        name: Optional[str] = None,
+        icon: str = "mdi-file",
+    ) -> Dict[str, Any]:
         """Upload a recipe asset file (multipart upload)
+
+        Mealie requires name, icon, and extension alongside the file. The
+        extension is derived from the filename and the display name defaults to
+        the filename stem, matching what the Mealie web UI sends.
 
         Args:
             slug: The slug identifier of the recipe
             asset_data: Binary asset data
             filename: Name of the asset file
+            name: Display name for the asset (defaults to the filename stem)
+            icon: mdi icon name shown next to the asset in the Mealie UI
 
         Returns:
             JSON response containing the uploaded asset details
@@ -326,10 +339,23 @@ class RecipeMixin:
         if not filename:
             raise ValueError("Filename cannot be empty")
 
+        stem, _, extension = filename.rpartition(".")
+        if not extension or not stem:
+            raise ValueError(
+                f"Asset filename must have an extension, got '{filename}'"
+            )
+
         files = {"file": (filename, asset_data)}
+        data = {
+            "name": name or stem,
+            "icon": icon,
+            "extension": extension,
+        }
 
         logger.info({"message": "Uploading recipe asset", "slug": slug, "filename": filename})
-        return self._handle_request("POST", f"/api/recipes/{slug}/assets", files=files)
+        return self._handle_request(
+            "POST", f"/api/recipes/{slug}/assets", files=files, data=data
+        )
 
     def delete_recipe(self, slug: str) -> Dict[str, Any]:
         """Delete a recipe

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -624,12 +624,23 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             raise ToolError(error_msg)
 
     @mcp.tool()
-    def upload_recipe_asset_file(slug: str, asset_path: str) -> Dict[str, Any]:
+    def upload_recipe_asset_file(
+        slug: str,
+        asset_path: str,
+        name: Optional[str] = None,
+        icon: str = "mdi-file",
+    ) -> Dict[str, Any]:
         """Upload an asset file (document, PDF, etc.) for a recipe.
 
         Args:
             slug: The unique text identifier for the recipe.
-            asset_path: Local file path to the asset to upload.
+            asset_path: Local file path to the asset to upload. Mealie derives
+                the stored filename from the name and rejects extensions
+                outside its allow-list with a 400.
+            name: Display name for the asset (defaults to the filename stem).
+            icon: mdi icon shown next to the asset in the Mealie UI. The UI
+                offers mdi-file (default), mdi-file-pdf-box, mdi-file-image,
+                mdi-code-json, and mdi-silverware-fork-knife.
 
         Returns:
             Dict[str, Any]: Details of the uploaded asset.
@@ -648,7 +659,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 asset_data = f.read()
 
             filename = os.path.basename(asset_path)
-            return mealie.upload_recipe_asset(slug, asset_data, filename)
+            return mealie.upload_recipe_asset(
+                slug, asset_data, filename, name=name, icon=icon
+            )
         except Exception as e:
             error_msg = f"Error uploading recipe asset '{slug}': {str(e)}"
             logger.error({"message": error_msg})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from mcp.server.fastmcp import FastMCP
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mealie import MealieFetcher  # noqa: E402
+from mealie.client import MealieApiError  # noqa: E402
 from tools import register_all_tools  # noqa: E402
 
 # A minimal but schema-valid recipe payload (satisfies the required Recipe
@@ -43,6 +44,12 @@ class FakeFetcher(MealieFetcher):
         self.requests = []
         self.created_slug = "test-recipe"
         self.recipe = dict(BASE_RECIPE)
+        # url fragment -> MealieApiError to raise, for client-failure tests
+        self.failures = {}
+
+    def fail_on(self, url_contains, status_code=422, message="Mealie rejected it"):
+        """Make any request whose url contains this fragment raise."""
+        self.failures[url_contains] = MealieApiError(status_code, message)
 
     def _handle_request(self, method, url, **kwargs):
         self.requests.append(
@@ -51,8 +58,13 @@ class FakeFetcher(MealieFetcher):
                 "url": url,
                 "json": kwargs.get("json"),
                 "params": kwargs.get("params"),
+                "data": kwargs.get("data"),
+                "files": kwargs.get("files"),
             }
         )
+        for fragment, error in self.failures.items():
+            if fragment in url:
+                raise error
         if method == "POST" and url == "/api/recipes":
             name = (kwargs.get("json") or {}).get("name")
             if name:
@@ -61,6 +73,13 @@ class FakeFetcher(MealieFetcher):
             return self.created_slug
         if method == "GET" and url.startswith("/api/recipes/") and url.count("/") == 3:
             return dict(self.recipe)
+        if method == "POST" and url.endswith("/assets"):
+            data = kwargs.get("data") or {}
+            return {
+                "name": data.get("name"),
+                "icon": data.get("icon"),
+                "fileName": f"{data.get('name')}.{data.get('extension')}",
+            }
         if method in ("PUT", "PATCH") and url.startswith("/api/recipes/"):
             return kwargs.get("json", {})
         # single-record GET (the fetch-merge update path reads the existing record)

--- a/tests/test_recipe_tools.py
+++ b/tests/test_recipe_tools.py
@@ -1,6 +1,9 @@
 """Tests for the recipe-authoring tools (structured ingredients, full create,
 patch fields, concise output)."""
 
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
 
 async def test_create_recipe_accepts_flat_and_structured(invoke, fetcher):
     await invoke(
@@ -120,3 +123,71 @@ async def test_get_recipe_concise_includes_orgurl_tags_tools(invoke, fetcher):
     assert out["orgURL"] == "https://example.com/r"
     assert out["tags"] == [{"id": "t1", "name": "Quick", "slug": "quick"}]
     assert out["tools"][0]["name"] == "Pfanne"
+
+
+async def test_upload_recipe_asset_sends_name_icon_and_extension(invoke, fetcher, tmp_path):
+    asset = tmp_path / "braise-notes.pdf"
+    asset.write_bytes(b"%PDF-1.4 fake")
+
+    await invoke("upload_recipe_asset_file", slug="test-recipe", asset_path=str(asset))
+
+    req = fetcher.last("POST", "/assets")
+    assert req["url"] == "/api/recipes/test-recipe/assets"
+    # Mealie requires all three form fields; extension is sent without the dot
+    assert req["data"] == {
+        "name": "braise-notes",
+        "icon": "mdi-file",
+        "extension": "pdf",
+    }
+    assert req["files"]["file"][0] == "braise-notes.pdf"
+    # multipart only: no JSON body, so httpx picks the boundary content type
+    assert req["json"] is None
+
+
+async def test_upload_recipe_asset_honours_explicit_name_and_icon(invoke, fetcher, tmp_path):
+    asset = tmp_path / "scan.PDF"
+    asset.write_bytes(b"%PDF-1.4 fake")
+
+    await invoke(
+        "upload_recipe_asset_file",
+        slug="test-recipe",
+        asset_path=str(asset),
+        name="Original scan",
+        icon="mdi-file-pdf-box",
+    )
+
+    assert fetcher.last("POST", "/assets")["data"] == {
+        "name": "Original scan",
+        "icon": "mdi-file-pdf-box",
+        "extension": "PDF",
+    }
+
+
+async def test_upload_recipe_asset_rejects_extensionless_filename(invoke, fetcher, tmp_path):
+    asset = tmp_path / "README"
+    asset.write_bytes(b"no extension")
+
+    with pytest.raises(ToolError, match="must have an extension"):
+        await invoke("upload_recipe_asset_file", slug="test-recipe", asset_path=str(asset))
+
+    assert fetcher.last("POST", "/assets") is None
+
+
+async def test_upload_recipe_asset_reports_missing_file(invoke, fetcher, tmp_path):
+    with pytest.raises(ToolError, match="Asset file not found"):
+        await invoke(
+            "upload_recipe_asset_file",
+            slug="test-recipe",
+            asset_path=str(tmp_path / "absent.pdf"),
+        )
+
+    assert fetcher.last("POST", "/assets") is None
+
+
+async def test_upload_recipe_asset_surfaces_client_failure(invoke, fetcher, tmp_path):
+    asset = tmp_path / "notes.pdf"
+    asset.write_bytes(b"%PDF-1.4 fake")
+    fetcher.fail_on("/assets", 400, "Unsupported file extension")
+
+    with pytest.raises(ToolError, match="Error uploading recipe asset"):
+        await invoke("upload_recipe_asset_file", slug="test-recipe", asset_path=str(asset))


### PR DESCRIPTION
> Authored with [Claude Code](https://claude.com/claude-code); the commits carry a
> `Co-Authored-By` trailer. Everything described below was verified against a live
> Mealie v3.22.0 instance, not just against the test suite.

`upload_recipe_asset_file` fails on every call. `POST /api/recipes/{slug}/assets` takes four multipart fields; only the file was being sent:

```
API error for POST /api/recipes/{slug}/assets:
{'detail': [
  {'type': 'missing', 'loc': ['body', 'name'],      'msg': 'Field required'},
  {'type': 'missing', 'loc': ['body', 'icon'],      'msg': 'Field required'},
  {'type': 'missing', 'loc': ['body', 'extension'], 'msg': 'Field required'}
]} (Status Code: 422)
```

## The fix

The extension is derived from the filename and the display name defaults to the filename stem, matching what the web UI sends (`RecipeAssets.vue` — it also falls back to the file's base name). The icon defaults to `mdi-file`, the UI's own default. `name` and `icon` are exposed as optional tool arguments so callers can override them; the existing two-argument call still works unchanged.

A filename with no extension is rejected before the request rather than becoming a 400, since Mealie derives the stored filename from it.

## Testing

Five new tests: the multipart body contents, explicit name/icon override, extensionless filename, missing file, and a client failure surfacing as a `ToolError`. `FakeFetcher` gained two things it needed to test any of this — it now records the `data` and `files` kwargs (without which a multipart test asserts on `None`), and `fail_on()` raises a `MealieApiError` for a chosen endpoint.

Verified against a live Mealie v3.22.0 instance with a real PDF: uploaded, stored, and retrieved back at the exact byte count with `content-type: application/pdf`. Also checked a filename containing a space, which Mealie slugifies into the stored name.

`ruff check src tests` and `pytest` pass (60 → 65).

---

I have three other small PRs open against this repo (recipe nutrition, recipe notes, and the ingredient parser). They're independent and can be taken in any order or declined separately, but each adds a `CHANGELOG.md` that the README already links to, so whichever merges second will need a trivial conflict resolution there. Happy to rebase whenever you like.
