### PR TITLE
feat: accept nutrition on create_recipe_full and patch_recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `create_recipe_full` and `patch_recipe` accept a `nutrition` argument covering
+  Mealie's full key set (calories, macros, cholesterol, sodium, sugars, and the
+  fat breakdown). Numbers are converted to the strings Mealie stores. Mealie
+  replaces the whole nutrition object on write, so `patch_recipe` clears any key
+  not passed.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive Model Context Protocol (MCP) server that enables AI assistants t
 - **Image Management**: Upload images or scrape from URLs
 - **Asset Uploads**: Attach documents and files to recipes
 - **Metadata Tracking**: Mark recipes as made, track last made dates
+- **Nutrition**: Set per-serving nutrition when creating or patching a recipe
 
 ### 🛒 Shopping Lists
 
@@ -122,9 +123,9 @@ Restart Claude Desktop to load the server.
 - `get_recipe_detailed` - Get complete recipe details
 - `get_recipe_concise` - Get recipe summary
 - `create_recipe` - Create new recipe (flat or structured ingredients)
-- `create_recipe_full` - Create a recipe with full content in one call
+- `create_recipe_full` - Create a recipe with full content (including nutrition) in one call
 - `update_recipe` - Update recipe (full replacement)
-- `patch_recipe` - Update specific fields only
+- `patch_recipe` - Update specific fields only (including nutrition)
 - `duplicate_recipe` - Clone a recipe
 - `mark_recipe_last_made` - Update last made timestamp
 - `set_recipe_image_from_url` - Set image from URL
@@ -276,6 +277,16 @@ When filtering recipes, you **must use slugs or UUIDs**, not display names:
 ```
 
 Use `get_tags()` or `get_categories()` first to find the correct slugs.
+
+### Nutrition Is Replaced, Not Merged
+
+Mealie replaces the whole `nutrition` object on write. `patch_recipe` follows
+suit, so pass every value you want to keep:
+
+```
+# clears every nutrition value except fat
+patch_recipe(slug="...", nutrition={"fatContent": "12"})
+```
 
 ### Field Preservation
 

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -80,6 +80,16 @@ And these instructions:
 "Update the yield of the soup recipe to '6 servings'"
 ```
 
+### Nutrition
+
+```
+"Add nutrition to the chicken curry: 520 calories, 31g protein, 18g fat,
+ 42g carbs, 780mg sodium"
+```
+
+Values are per serving. Mealie replaces the whole nutrition object, so ask for
+every value you want to keep in a single request.
+
 ### Recipe Images
 
 **From URL:**

--- a/src/models/recipe.py
+++ b/src/models/recipe.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class IngredientUnit(BaseModel):
@@ -58,17 +58,43 @@ class RecipeInstruction(BaseModel):
 
 
 class RecipeNutrition(BaseModel):
-    calories: Optional[str] = None
-    carbohydrateContent: Optional[str] = None
-    cholesterolContent: Optional[str] = None
-    fatContent: Optional[str] = None
-    fiberContent: Optional[str] = None
-    proteinContent: Optional[str] = None
-    saturatedFatContent: Optional[str] = None
-    sodiumContent: Optional[str] = None
-    sugarContent: Optional[str] = None
-    transFatContent: Optional[str] = None
-    unsaturatedFatContent: Optional[str] = None
+    """Per-serving nutrition values.
+
+    Mealie stores every value as a string holding a bare number, without a unit
+    suffix: calories in kcal, sodium and cholesterol in milligrams, everything
+    else in grams. Numbers are accepted and converted to strings.
+
+    Mealie replaces the whole nutrition object on write, so omitted keys are
+    cleared rather than preserved.
+    """
+
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+
+    calories: Optional[str] = Field(default=None, description="Energy in kcal.")
+    carbohydrateContent: Optional[str] = Field(
+        default=None, description="Carbohydrates in grams."
+    )
+    cholesterolContent: Optional[str] = Field(
+        default=None, description="Cholesterol in milligrams."
+    )
+    fatContent: Optional[str] = Field(default=None, description="Total fat in grams.")
+    fiberContent: Optional[str] = Field(
+        default=None, description="Dietary fiber in grams."
+    )
+    proteinContent: Optional[str] = Field(default=None, description="Protein in grams.")
+    saturatedFatContent: Optional[str] = Field(
+        default=None, description="Saturated fat in grams."
+    )
+    sodiumContent: Optional[str] = Field(
+        default=None, description="Sodium in milligrams."
+    )
+    sugarContent: Optional[str] = Field(default=None, description="Sugars in grams.")
+    transFatContent: Optional[str] = Field(
+        default=None, description="Trans fat in grams."
+    )
+    unsaturatedFatContent: Optional[str] = Field(
+        default=None, description="Unsaturated fat in grams."
+    )
 
 
 class RecipeSettings(BaseModel):

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -15,6 +15,7 @@ from models.recipe import (
     RecipeIngredientInput,
     RecipeInstruction,
     RecipeInstructionInput,
+    RecipeNutrition,
     RecipeTag,
     RecipeTool,
 )
@@ -365,6 +366,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         instructions: Optional[List[Union[str, RecipeInstructionInput]]] = None,
         tags: Optional[List[OrganizerRef]] = None,
         tools: Optional[List[OrganizerRef]] = None,
+        nutrition: Optional[RecipeNutrition] = None,
     ) -> Dict[str, Any]:
         """Create a recipe and populate all of its content in one call.
 
@@ -392,6 +394,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             instructions: Instruction strings and/or structured instruction objects.
             tags: Existing Mealie tags (id+name) to assign; look up with get_tags.
             tools: Existing Mealie tools (id+name) to assign; look up with get_tools.
+            nutrition: Per-serving nutrition values (calories in kcal, sodium and
+                cholesterol in mg, the rest in grams). Omitted keys stay empty.
 
         Returns:
             Dict[str, Any]: The created recipe details.
@@ -428,6 +432,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 recipe.tags = [RecipeTag(**_organizer_payload(t)) for t in tags]
             if tools is not None:
                 recipe.tools = [RecipeTool(**_organizer_payload(t)) for t in tools]
+            if nutrition is not None:
+                recipe.nutrition = nutrition
             _normalize_references(recipe)
 
             updated = mealie.update_recipe(slug, recipe.model_dump(exclude_none=True))
@@ -459,6 +465,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         org_url: Optional[str] = None,
         tags: Optional[List[OrganizerRef]] = None,
         tools: Optional[List[OrganizerRef]] = None,
+        nutrition: Optional[RecipeNutrition] = None,
     ) -> Dict[str, Any]:
         """Partially update a recipe (only updates provided fields).
 
@@ -475,6 +482,10 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             org_url: Source URL for the recipe (shown as a link in the Mealie UI).
             tags: Existing Mealie tags (id+name) to set; look up with get_tags.
             tools: Existing Mealie tools (id+name) to set; look up with get_tools.
+            nutrition: Per-serving nutrition values (calories in kcal, sodium and
+                cholesterol in mg, the rest in grams). Mealie replaces the whole
+                nutrition object, so pass every value you want to keep — omitted
+                keys are cleared, not preserved.
 
         Returns:
             Dict[str, Any]: The updated recipe details.
@@ -505,6 +516,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 recipe_data["tags"] = [_organizer_payload(t) for t in tags]
             if tools is not None:
                 recipe_data["tools"] = [_organizer_payload(t) for t in tools]
+            if nutrition is not None:
+                recipe_data["nutrition"] = nutrition.model_dump(exclude_none=True)
 
             if not recipe_data:
                 raise ValueError("At least one field must be provided to update")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from models.recipe import (
     Recipe,
     RecipeIngredientInput,
     RecipeInstructionInput,
+    RecipeNutrition,
 )
 
 
@@ -84,3 +85,13 @@ def test_recipe_instruction_input_serialisation():
 def test_organizer_ref_requires_id_and_name():
     org = OrganizerRef(id="t1", name="Quick")
     assert org.model_dump(exclude_none=True) == {"id": "t1", "name": "Quick"}
+
+
+def test_recipe_nutrition_coerces_numbers_to_strings():
+    nutrition = RecipeNutrition(calories=450, fatContent=31.5)
+    assert nutrition.calories == "450"
+    assert nutrition.fatContent == "31.5"
+    assert nutrition.model_dump(exclude_none=True) == {
+        "calories": "450",
+        "fatContent": "31.5",
+    }

--- a/tests/test_recipe_tools.py
+++ b/tests/test_recipe_tools.py
@@ -107,6 +107,37 @@ async def test_patch_recipe_maps_all_fields(invoke, fetcher):
     }
 
 
+async def test_create_recipe_full_sets_nutrition(invoke, fetcher):
+    await invoke(
+        "create_recipe_full",
+        name="Nutritious",
+        nutrition={"calories": "450", "proteinContent": 20, "sodiumContent": "310"},
+    )
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    # numbers are coerced to the strings Mealie stores; unset keys are omitted
+    assert body["nutrition"] == {
+        "calories": "450",
+        "proteinContent": "20",
+        "sodiumContent": "310",
+    }
+
+
+async def test_create_recipe_full_without_nutrition_sends_empty_object(invoke, fetcher):
+    await invoke("create_recipe_full", name="Plain", ingredients=["1 onion"])
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    assert body["nutrition"] == {}
+
+
+async def test_patch_recipe_sets_nutrition(invoke, fetcher):
+    await invoke(
+        "patch_recipe",
+        slug="test-recipe",
+        nutrition={"calories": "450", "fatContent": "12"},
+    )
+    body = fetcher.last("PATCH", "/api/recipes/")["json"]
+    assert body == {"nutrition": {"calories": "450", "fatContent": "12"}}
+
+
 async def test_get_recipe_concise_includes_orgurl_tags_tools(invoke, fetcher):
     fetcher.recipe = {
         **fetcher.recipe,


### PR DESCRIPTION
> Authored with [Claude Code](https://claude.com/claude-code); the commits carry a
> `Co-Authored-By` trailer. Everything described below was verified against a live
> Mealie v3.22.0 instance, not just against the test suite.

Mealie's recipe model carries a `nutrition` object, but neither `create_recipe_full` nor `patch_recipe` could set it, so recipes created through this server always have it null.

Both tools now take an optional `nutrition` argument typed as the existing `RecipeNutrition` model, which already mirrors Mealie's exact key set (`calories`, `carbohydrateContent`, `cholesterolContent`, `fatContent`, `fiberContent`, `proteinContent`, `saturatedFatContent`, `sodiumContent`, `sugarContent`, `transFatContent`, `unsaturatedFatContent`).

Two details worth flagging:

- The model gained `coerce_numbers_to_str`. Mealie stores these as strings, but a caller naturally passes `calories=450`; without coercion that's a validation error rather than a working call.
- The model gained per-field descriptions naming the unit Mealie expects — kcal for calories, mg for sodium and cholesterol, grams elsewhere. That's the kind of thing an LLM client otherwise has to guess.

## Replace, not merge

Mealie replaces the whole nutrition object on write rather than merging it — confirmed against a live instance, not assumed. Patching a single value clears the rest:

```
PATCH {"nutrition": {"calories": "450", "proteinContent": "20"}}   # then
PATCH {"nutrition": {"fatContent": "12"}}
# -> calories and protein are now null
```

`patch_recipe`'s docstring and the README say so explicitly. I didn't add merge logic — that seemed like scope beyond the gap, but happy to add it if you'd rather the tool preserved omitted keys.

## Testing

Four new tests: nutrition on create, nutrition on patch, the number-to-string coercion, and — the one I'd point at in review — an assertion that omitting `nutrition` leaves the PUT body exactly as it is today.

Verified against a live Mealie v3.22.0 instance on both the create and patch paths, with throwaway recipes deleted afterwards.

`ruff check src tests` and `pytest` pass (60 → 64).

---

I have three other small PRs open against this repo (the asset-upload 422 fix, recipe notes, and the ingredient parser). They're independent and can be taken in any order or declined separately, but each adds a `CHANGELOG.md` that the README already links to, so whichever merges second will need a trivial conflict resolution there. Happy to rebase whenever you like.
