### PR TITLE
feat: accept notes on create_recipe_full and patch_recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `create_recipe_full` and `patch_recipe` accept a `notes` argument for Mealie's
+  `{title, text}` notes. Mealie requires a title but accepts an empty one, so
+  the title defaults to `""`. `patch_recipe` replaces all notes; an empty list
+  clears them.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive Model Context Protocol (MCP) server that enables AI assistants t
 - **Image Management**: Upload images or scrape from URLs
 - **Asset Uploads**: Attach documents and files to recipes
 - **Metadata Tracking**: Mark recipes as made, track last made dates
+- **Notes**: Attach substitution, storage, and variation notes to a recipe
 
 ### 🛒 Shopping Lists
 
@@ -122,9 +123,9 @@ Restart Claude Desktop to load the server.
 - `get_recipe_detailed` - Get complete recipe details
 - `get_recipe_concise` - Get recipe summary
 - `create_recipe` - Create new recipe (flat or structured ingredients)
-- `create_recipe_full` - Create a recipe with full content in one call
+- `create_recipe_full` - Create a recipe with full content (including notes) in one call
 - `update_recipe` - Update recipe (full replacement)
-- `patch_recipe` - Update specific fields only
+- `patch_recipe` - Update specific fields only (including notes)
 - `duplicate_recipe` - Clone a recipe
 - `mark_recipe_last_made` - Update last made timestamp
 - `set_recipe_image_from_url` - Set image from URL
@@ -276,6 +277,11 @@ When filtering recipes, you **must use slugs or UUIDs**, not display names:
 ```
 
 Use `get_tags()` or `get_categories()` first to find the correct slugs.
+
+### Notes Are Replaced, Not Merged
+
+`patch_recipe` replaces the whole `notes` array, the same way it already treats
+`tags` and `tools`. Pass every note you want to keep; an empty list clears them.
 
 ### Field Preservation
 

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -80,6 +80,17 @@ And these instructions:
 "Update the yield of the soup recipe to '6 servings'"
 ```
 
+### Notes
+
+```
+"Add a note to the sourdough recipe titled 'Storage': keeps 4 days wrapped
+ in a tea towel, or 3 months frozen"
+"Add a substitution note to the brownies: swap the butter for coconut oil
+ to make it dairy-free"
+```
+
+Notes are replaced as a set, so ask for every note you want to keep.
+
 ### Recipe Images
 
 **From URL:**

--- a/src/models/recipe.py
+++ b/src/models/recipe.py
@@ -71,6 +71,19 @@ class RecipeNutrition(BaseModel):
     unsaturatedFatContent: Optional[str] = None
 
 
+class RecipeNote(BaseModel):
+    """A free-text note attached to a recipe.
+
+    Cookbooks use these for substitutions, storage advice, and variations.
+    Mealie requires a title on every note; it may be empty but not absent.
+    """
+
+    title: str = Field(
+        default="", description='Heading for the note, e.g. "Storage" or "Variations".'
+    )
+    text: str = Field(description="Body of the note.")
+
+
 class RecipeSettings(BaseModel):
     public: bool = False
     showNutrition: bool = False

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -15,6 +15,7 @@ from models.recipe import (
     RecipeIngredientInput,
     RecipeInstruction,
     RecipeInstructionInput,
+    RecipeNote,
     RecipeTag,
     RecipeTool,
 )
@@ -365,6 +366,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         instructions: Optional[List[Union[str, RecipeInstructionInput]]] = None,
         tags: Optional[List[OrganizerRef]] = None,
         tools: Optional[List[OrganizerRef]] = None,
+        notes: Optional[List[RecipeNote]] = None,
     ) -> Dict[str, Any]:
         """Create a recipe and populate all of its content in one call.
 
@@ -392,6 +394,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             instructions: Instruction strings and/or structured instruction objects.
             tags: Existing Mealie tags (id+name) to assign; look up with get_tags.
             tools: Existing Mealie tools (id+name) to assign; look up with get_tools.
+            notes: Free-text notes ({title, text}) for substitutions, storage
+                advice, and variations.
 
         Returns:
             Dict[str, Any]: The created recipe details.
@@ -428,6 +432,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 recipe.tags = [RecipeTag(**_organizer_payload(t)) for t in tags]
             if tools is not None:
                 recipe.tools = [RecipeTool(**_organizer_payload(t)) for t in tools]
+            if notes is not None:
+                recipe.notes = [n.model_dump() for n in notes]
             _normalize_references(recipe)
 
             updated = mealie.update_recipe(slug, recipe.model_dump(exclude_none=True))
@@ -459,6 +465,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         org_url: Optional[str] = None,
         tags: Optional[List[OrganizerRef]] = None,
         tools: Optional[List[OrganizerRef]] = None,
+        notes: Optional[List[RecipeNote]] = None,
     ) -> Dict[str, Any]:
         """Partially update a recipe (only updates provided fields).
 
@@ -475,6 +482,9 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             org_url: Source URL for the recipe (shown as a link in the Mealie UI).
             tags: Existing Mealie tags (id+name) to set; look up with get_tags.
             tools: Existing Mealie tools (id+name) to set; look up with get_tools.
+            notes: Free-text notes ({title, text}) for substitutions, storage
+                advice, and variations. Replaces all existing notes; pass an
+                empty list to remove them.
 
         Returns:
             Dict[str, Any]: The updated recipe details.
@@ -505,6 +515,8 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 recipe_data["tags"] = [_organizer_payload(t) for t in tags]
             if tools is not None:
                 recipe_data["tools"] = [_organizer_payload(t) for t in tools]
+            if notes is not None:
+                recipe_data["notes"] = [n.model_dump() for n in notes]
 
             if not recipe_data:
                 raise ValueError("At least one field must be provided to update")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,12 +1,15 @@
 """Tests for the Pydantic recipe models, including the typing fixes."""
 
+import pytest
 from conftest import BASE_RECIPE
+from pydantic import ValidationError
 
 from models.recipe import (
     OrganizerRef,
     Recipe,
     RecipeIngredientInput,
     RecipeInstructionInput,
+    RecipeNote,
 )
 
 
@@ -84,3 +87,13 @@ def test_recipe_instruction_input_serialisation():
 def test_organizer_ref_requires_id_and_name():
     org = OrganizerRef(id="t1", name="Quick")
     assert org.model_dump(exclude_none=True) == {"id": "t1", "name": "Quick"}
+
+
+def test_recipe_note_requires_text():
+    with pytest.raises(ValidationError):
+        RecipeNote(title="Storage")
+
+
+def test_recipe_note_title_defaults_to_empty_string():
+    assert RecipeNote(text="Swap butter for oil.").title == ""
+

--- a/tests/test_recipe_tools.py
+++ b/tests/test_recipe_tools.py
@@ -107,6 +107,39 @@ async def test_patch_recipe_maps_all_fields(invoke, fetcher):
     }
 
 
+async def test_create_recipe_full_sets_notes(invoke, fetcher):
+    await invoke(
+        "create_recipe_full",
+        name="Noted",
+        notes=[
+            {"title": "Storage", "text": "Keeps 3 days refrigerated."},
+            {"text": "Swap butter for oil."},
+        ],
+    )
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    # Mealie requires a title on every note; it defaults to empty, never absent
+    assert body["notes"] == [
+        {"title": "Storage", "text": "Keeps 3 days refrigerated."},
+        {"title": "", "text": "Swap butter for oil."},
+    ]
+
+
+async def test_patch_recipe_replaces_notes(invoke, fetcher):
+    await invoke(
+        "patch_recipe",
+        slug="test-recipe",
+        notes=[{"title": "Tip", "text": "Toast the spices."}],
+    )
+    body = fetcher.last("PATCH", "/api/recipes/")["json"]
+    assert body == {"notes": [{"title": "Tip", "text": "Toast the spices."}]}
+
+
+async def test_patch_recipe_clears_notes_with_empty_list(invoke, fetcher):
+    await invoke("patch_recipe", slug="test-recipe", notes=[])
+    body = fetcher.last("PATCH", "/api/recipes/")["json"]
+    assert body == {"notes": []}
+
+
 async def test_get_recipe_concise_includes_orgurl_tags_tools(invoke, fetcher):
     fetcher.recipe = {
         **fetcher.recipe,


### PR DESCRIPTION
> Authored with [Claude Code](https://claude.com/claude-code); the commits carry a
> `Co-Authored-By` trailer. Everything described below was verified against a live
> Mealie v3.22.0 instance, not just against the test suite.

Recipes carry `notes: [{title, text}]`, which cookbooks lean on constantly for substitution tips, storage advice, and variations. Nothing in the server could reach them, so that content was lost on import.

Adds a `RecipeNote` model and an optional `notes` argument to `create_recipe_full` and `patch_recipe`.

## The title default

Mealie's schema marks `title` as required, and omitting it is a hard 422:

```
{'type': 'missing', 'loc': ['body', 'notes', 0, 'title'], 'msg': 'Field required'}
```

An empty string is accepted, though. Plenty of cookbook notes are a bare sentence with no natural heading, so the model defaults `title` to `""` rather than forcing callers to invent one. Callers who have a heading just pass it.

## Replace, not merge

`patch_recipe` replaces the whole notes array, matching how it already treats `tags` and `tools`. An empty list clears them. Documented in the docstring and README.

## Testing

Five new tests: notes on create (including the title default), notes on patch, clearing with an empty list, and both model-level cases.

Verified against a live Mealie v3.22.0 instance on both paths, with throwaway recipes deleted afterwards.

`ruff check src tests` and `pytest` pass (60 → 65).

---

I have three other small PRs open against this repo (the asset-upload 422 fix, recipe nutrition, and the ingredient parser). They're independent and can be taken in any order or declined separately, but each adds a `CHANGELOG.md` that the README already links to, so whichever merges second will need a trivial conflict resolution there. Happy to rebase whenever you like.
