### PR TITLE
feat: expose Mealie's ingredient parser as parse_ingredient(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `parse_ingredient` and `parse_ingredients` wrap Mealie's server-side
+  ingredient parser, resolving free text such as `"1/4 cup chopped onion"`
+  against the instance's food and unit vocabulary in one request instead of
+  searching `get_foods` and `get_units` per ingredient. Results are flattened to
+  `{input, confidence, quantity, unit, food, note}` and can be passed straight
+  to `create_recipe_full`; `verbose=True` returns Mealie's untouched response.
+  Both accept Mealie's `nlp`, `brute`, and `openai` parser backends.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive Model Context Protocol (MCP) server that enables AI assistants t
 - **Image Management**: Upload images or scrape from URLs
 - **Asset Uploads**: Attach documents and files to recipes
 - **Metadata Tracking**: Mark recipes as made, track last made dates
+- **Ingredient Parsing**: Resolve free-text ingredients against your food and unit vocabulary
 
 ### 🛒 Shopping Lists
 
@@ -191,6 +192,11 @@ Restart Claude Desktop to load the server.
 - `update_tool` - Update tool
 - `delete_tool` - Delete tool
 
+### Parser Tools (2 operations)
+
+- `parse_ingredient` - Resolve one free-text ingredient line
+- `parse_ingredients` - Resolve a whole recipe's ingredients in one request
+
 ### Meal Plan Tools (4 operations)
 
 - `get_all_mealplans` - List meal plans
@@ -242,6 +248,7 @@ mealie-mcp-server/
 │   │   ├── categories.py    # Category operations
 │   │   ├── tags.py          # Tag operations
 │   │   ├── mealplan.py      # Meal plan operations
+│   │   ├── parser.py        # Ingredient parser
 │   │   └── __init__.py      # MealieFetcher aggregator
 │   ├── tools/               # MCP tool definitions
 │   │   ├── recipe_tools.py
@@ -249,6 +256,7 @@ mealie-mcp-server/
 │   │   ├── categories_tools.py
 │   │   ├── tags_tools.py
 │   │   ├── mealplan_tools.py
+│   │   ├── parser_tools.py
 │   │   └── __init__.py
 │   ├── models/              # Pydantic models
 │   ├── server.py            # MCP server entry point
@@ -276,6 +284,23 @@ When filtering recipes, you **must use slugs or UUIDs**, not display names:
 ```
 
 Use `get_tags()` or `get_categories()` first to find the correct slugs.
+
+### Parsing Ingredients in Bulk
+
+Resolving ingredients by hand costs one to two `get_foods` / `get_units` calls
+each. `parse_ingredients` does a whole recipe in one request and returns results
+that can be handed straight to `create_recipe_full`:
+
+```
+parse_ingredients(ingredients=["1/4 cup chopped onion", "2 large eggs"])
+# -> [{"input": "1/4 cup chopped onion", "confidence": 0.99, "quantity": 0.25,
+#      "unit": {"id": "...", "name": "cup"},
+#      "food": {"id": "...", "name": "onion"}, "note": "chopped"}, ...]
+```
+
+A `null` unit or food means your instance has no matching entry — create one
+with `create_food` / `create_unit`, or leave the text in the note. Pass
+`verbose=True` for Mealie's full response including per-field confidences.
 
 ### Field Preservation
 

--- a/USAGE_EXAMPLES.md
+++ b/USAGE_EXAMPLES.md
@@ -80,6 +80,19 @@ And these instructions:
 "Update the yield of the soup recipe to '6 servings'"
 ```
 
+### Parsing Ingredients
+
+```
+"Parse these ingredients against my Mealie vocabulary, then create the recipe:
+- 1/4 cup chopped onion
+- 2 large eggs
+- a pinch of salt"
+```
+
+One request resolves all of them into quantities, units, and foods with the ids
+needed to create the recipe. Ingredients your instance doesn't know come back
+with a null food or unit, so you can decide whether to add them.
+
 ### Recipe Images
 
 **From URL:**

--- a/src/mealie/__init__.py
+++ b/src/mealie/__init__.py
@@ -3,6 +3,7 @@ from .client import MealieClient
 from .foods import FoodsMixin
 from .group import GroupMixin
 from .mealplan import MealplanMixin
+from .parser import ParserMixin
 from .recipe import RecipeMixin
 from .shopping_list import ShoppingListMixin
 from .tags import TagsMixin
@@ -18,6 +19,7 @@ class MealieFetcher(
     FoodsMixin,
     UnitsMixin,
     ToolsMixin,
+    ParserMixin,
     ShoppingListMixin,
     MealplanMixin,
     UserMixin,

--- a/src/mealie/parser.py
+++ b/src/mealie/parser.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Any, Dict, List
+
+logger = logging.getLogger("mealie-mcp")
+
+
+class ParserMixin:
+    """Mixin class for Mealie's ingredient parser endpoints"""
+
+    def parse_ingredient(
+        self, ingredient: str, parser: str = "nlp"
+    ) -> Dict[str, Any]:
+        """Parse a single ingredient string into structured components
+
+        Args:
+            ingredient: Free-text ingredient line, e.g. "1/4 cup chopped onion"
+            parser: Parser backend: 'nlp', 'brute', or 'openai'
+
+        Returns:
+            JSON response with the input, per-field confidences, and the
+            resolved ingredient
+        """
+        if not ingredient:
+            raise ValueError("Ingredient cannot be empty")
+
+        logger.info({"message": "Parsing ingredient", "parser": parser})
+        return self._handle_request(
+            "POST",
+            "/api/parser/ingredient",
+            json={"ingredient": ingredient, "parser": parser},
+        )
+
+    def parse_ingredients(
+        self, ingredients: List[str], parser: str = "nlp"
+    ) -> List[Dict[str, Any]]:
+        """Parse several ingredient strings in a single request
+
+        Args:
+            ingredients: Free-text ingredient lines
+            parser: Parser backend: 'nlp', 'brute', or 'openai'
+
+        Returns:
+            JSON response with one parse result per input, in the same order
+        """
+        if not ingredients:
+            raise ValueError("Ingredients cannot be empty")
+
+        logger.info(
+            {
+                "message": "Parsing ingredients",
+                "parser": parser,
+                "count": len(ingredients),
+            }
+        )
+        return self._handle_request(
+            "POST",
+            "/api/parser/ingredients",
+            json={"ingredients": ingredients, "parser": parser},
+        )

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,6 +1,7 @@
 from .categories_tools import register_categories_tools
 from .foods_tools import register_foods_tools
 from .mealplan_tools import register_mealplan_tools
+from .parser_tools import register_parser_tools
 from .recipe_tools import register_recipe_tools
 from .shopping_list_tools import register_shopping_list_tools
 from .tags_tools import register_tags_tools
@@ -18,6 +19,7 @@ def register_all_tools(mcp, mealie):
     register_tools_tools(mcp, mealie)
     register_shopping_list_tools(mcp, mealie)
     register_mealplan_tools(mcp, mealie)
+    register_parser_tools(mcp, mealie)
 
 
 __all__ = [
@@ -30,4 +32,5 @@ __all__ = [
     "register_tools_tools",
     "register_shopping_list_tools",
     "register_mealplan_tools",
+    "register_parser_tools",
 ]

--- a/src/tools/parser_tools.py
+++ b/src/tools/parser_tools.py
@@ -1,0 +1,131 @@
+import logging
+import traceback
+from typing import Any, Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+
+from mealie import MealieFetcher
+
+logger = logging.getLogger("mealie-mcp")
+
+_PARSERS = ("nlp", "brute", "openai")
+
+
+def _organizer_ref(value: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Reduce a parsed food/unit to the {id, name} pair the recipe tools need."""
+    if not value:
+        return None
+    return {"id": value.get("id"), "name": value.get("name")}
+
+
+def _flatten(parsed: Dict[str, Any]) -> Dict[str, Any]:
+    """Reduce a Mealie ParsedIngredient to a RecipeIngredientInput-shaped dict.
+
+    Mealie returns the full food and unit records plus a per-field confidence
+    breakdown. Only the ids and names are needed to build a recipe, so the rest
+    is dropped and the confidences collapse to their average; pass verbose=True
+    to the tool to get the untouched response instead.
+    """
+    ingredient = parsed.get("ingredient") or {}
+    return {
+        "input": parsed.get("input"),
+        "confidence": (parsed.get("confidence") or {}).get("average"),
+        "quantity": ingredient.get("quantity"),
+        "unit": _organizer_ref(ingredient.get("unit")),
+        "food": _organizer_ref(ingredient.get("food")),
+        "note": ingredient.get("note"),
+    }
+
+
+def _validate_parser(parser: str) -> None:
+    if parser not in _PARSERS:
+        raise ValueError(f"parser must be one of {', '.join(_PARSERS)}, got '{parser}'")
+
+
+def register_parser_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
+    """Register the ingredient-parser tools with the MCP server."""
+
+    @mcp.tool()
+    def parse_ingredient(
+        ingredient: str, parser: str = "nlp", verbose: bool = False
+    ) -> Dict[str, Any]:
+        """Resolve one free-text ingredient line against Mealie's vocabulary.
+
+        Mealie's server-side parser turns "1/4 cup chopped onion" into
+        quantity 0.25, the existing "cup" unit, the existing "onion" food, and
+        the note "chopped" — in one call, instead of searching get_foods and
+        get_units per ingredient. Use parse_ingredients for a whole recipe.
+
+        The returned unit and food carry the ids create_recipe_full needs, so a
+        result can be passed straight through as a structured ingredient.
+        A null unit or food means Mealie has no matching entry; create one with
+        create_food or create_unit, or leave the text in the note.
+
+        Confidence is Mealie's own 0-1 score; low values are worth checking
+        against the source text before writing the recipe.
+
+        Args:
+            ingredient: The ingredient line to parse, e.g. "1/4 cup chopped onion".
+            parser: Parser backend — "nlp" (default, trained model), "brute"
+                (regex splitting, better for terse or unusual formats), or
+                "openai" (only if the Mealie server is configured for it).
+            verbose: If True, return Mealie's untouched response, including the
+                full food/unit records and the per-field confidence breakdown.
+
+        Returns:
+            Dict[str, Any]: input, confidence, quantity, unit, food, and note.
+        """
+        try:
+            _validate_parser(parser)
+            logger.info({"message": "Parsing ingredient", "parser": parser})
+            parsed = mealie.parse_ingredient(ingredient, parser=parser)
+            return parsed if verbose else _flatten(parsed)
+        except Exception as e:
+            error_msg = f"Error parsing ingredient: {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
+    def parse_ingredients(
+        ingredients: List[str], parser: str = "nlp", verbose: bool = False
+    ) -> List[Dict[str, Any]]:
+        """Resolve a whole recipe's ingredient lines in a single call.
+
+        Same parser as parse_ingredient, batched — the efficient way to prepare
+        ingredients before create_recipe_full or update_recipe. Results come
+        back in input order, one per line.
+
+        Args:
+            ingredients: The ingredient lines to parse, in recipe order.
+            parser: Parser backend — "nlp" (default, trained model), "brute"
+                (regex splitting, better for terse or unusual formats), or
+                "openai" (only if the Mealie server is configured for it).
+            verbose: If True, return Mealie's untouched responses, including the
+                full food/unit records and the per-field confidence breakdown.
+
+        Returns:
+            List[Dict[str, Any]]: One result per input line, in the same order,
+            each with input, confidence, quantity, unit, food, and note.
+        """
+        try:
+            _validate_parser(parser)
+            logger.info(
+                {
+                    "message": "Parsing ingredients",
+                    "parser": parser,
+                    "count": len(ingredients),
+                }
+            )
+            parsed = mealie.parse_ingredients(ingredients, parser=parser)
+            return parsed if verbose else [_flatten(p) for p in parsed]
+        except Exception as e:
+            error_msg = f"Error parsing ingredients: {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from mcp.server.fastmcp import FastMCP
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mealie import MealieFetcher  # noqa: E402
+from mealie.client import MealieApiError  # noqa: E402
 from tools import register_all_tools  # noqa: E402
 
 # A minimal but schema-valid recipe payload (satisfies the required Recipe
@@ -32,6 +33,47 @@ BASE_RECIPE = {
 }
 
 
+def _parsed(text):
+    """A ParsedIngredient shaped like Mealie's, with the full food/unit records.
+
+    Unit is left unmatched so the flattening keeps a null visible.
+    """
+    return {
+        "input": text,
+        "confidence": {
+            "average": 0.996,
+            "comment": 0.993,
+            "name": None,
+            "unit": 0.999,
+            "quantity": 1.0,
+            "food": 0.991,
+        },
+        "ingredient": {
+            "quantity": 0.25,
+            "unit": None,
+            "food": {
+                "id": "a0819c33-1a5e-4374-9151-ed85160c0049",
+                "name": "onion",
+                "pluralName": "onions",
+                "description": "",
+                "extras": {},
+                "labelId": None,
+                "aliases": [],
+                "householdsWithIngredientFood": [],
+                "label": None,
+                "createdAt": "2026-08-03T02:15:22.603088Z",
+                "updatedAt": "2026-08-03T02:15:22.603092Z",
+            },
+            "referencedRecipe": None,
+            "note": "chopped",
+            "display": "¹/₄ cup onion chopped",
+            "title": None,
+            "originalText": None,
+            "referenceId": "75e1853f-3cb1-49b9-b2ca-26ae76da256b",
+        },
+    }
+
+
 class FakeFetcher(MealieFetcher):
     """MealieFetcher with the network layer replaced by a recorder.
 
@@ -43,6 +85,12 @@ class FakeFetcher(MealieFetcher):
         self.requests = []
         self.created_slug = "test-recipe"
         self.recipe = dict(BASE_RECIPE)
+        # url fragment -> MealieApiError to raise, for client-failure tests
+        self.failures = {}
+
+    def fail_on(self, url_contains, status_code=422, message="Mealie rejected it"):
+        """Make any request whose url contains this fragment raise."""
+        self.failures[url_contains] = MealieApiError(status_code, message)
 
     def _handle_request(self, method, url, **kwargs):
         self.requests.append(
@@ -53,6 +101,9 @@ class FakeFetcher(MealieFetcher):
                 "params": kwargs.get("params"),
             }
         )
+        for fragment, error in self.failures.items():
+            if fragment in url:
+                raise error
         if method == "POST" and url == "/api/recipes":
             name = (kwargs.get("json") or {}).get("name")
             if name:
@@ -61,6 +112,12 @@ class FakeFetcher(MealieFetcher):
             return self.created_slug
         if method == "GET" and url.startswith("/api/recipes/") and url.count("/") == 3:
             return dict(self.recipe)
+        if method == "POST" and url == "/api/parser/ingredient":
+            return _parsed((kwargs.get("json") or {}).get("ingredient"))
+        if method == "POST" and url == "/api/parser/ingredients":
+            return [
+                _parsed(text) for text in (kwargs.get("json") or {}).get("ingredients", [])
+            ]
         if method in ("PUT", "PATCH") and url.startswith("/api/recipes/"):
             return kwargs.get("json", {})
         # single-record GET (the fetch-merge update path reads the existing record)

--- a/tests/test_parser_tools.py
+++ b/tests/test_parser_tools.py
@@ -1,0 +1,113 @@
+"""Tests for the ingredient-parser tools (single, batch, flattening, verbose)."""
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
+FOOD_ID = "a0819c33-1a5e-4374-9151-ed85160c0049"
+
+
+async def test_parse_ingredient_posts_to_parser_endpoint(invoke, fetcher):
+    await invoke("parse_ingredient", ingredient="1/4 cup chopped onion")
+
+    req = fetcher.last("POST", "/api/parser/ingredient")
+    assert req["url"] == "/api/parser/ingredient"
+    assert req["json"] == {"ingredient": "1/4 cup chopped onion", "parser": "nlp"}
+
+
+async def test_parse_ingredient_flattens_to_recipe_ingredient_shape(invoke, fetcher):
+    out = await invoke("parse_ingredient", ingredient="1/4 cup chopped onion")
+
+    # exactly the fields create_recipe_full accepts, plus input/confidence
+    assert out == {
+        "input": "1/4 cup chopped onion",
+        "confidence": 0.996,
+        "quantity": 0.25,
+        "unit": None,  # unmatched vocabulary stays visible as null
+        "food": {"id": FOOD_ID, "name": "onion"},
+        "note": "chopped",
+    }
+
+
+async def test_parse_ingredient_verbose_returns_untouched_response(invoke, fetcher):
+    out = await invoke(
+        "parse_ingredient", ingredient="1/4 cup chopped onion", verbose=True
+    )
+
+    assert out["ingredient"]["food"]["pluralName"] == "onions"
+    assert out["confidence"]["quantity"] == 1.0
+
+
+async def test_parse_ingredient_forwards_parser_choice(invoke, fetcher):
+    await invoke("parse_ingredient", ingredient="2 eggs", parser="brute")
+
+    assert fetcher.last("POST", "/api/parser/ingredient")["json"]["parser"] == "brute"
+
+
+async def test_parse_ingredient_rejects_unknown_parser(invoke, fetcher):
+    with pytest.raises(ToolError, match="parser must be one of"):
+        await invoke("parse_ingredient", ingredient="2 eggs", parser="magic")
+
+    assert fetcher.last("POST", "/api/parser/ingredient") is None
+
+
+async def test_parse_ingredient_rejects_empty_input(invoke, fetcher):
+    with pytest.raises(ToolError, match="Ingredient cannot be empty"):
+        await invoke("parse_ingredient", ingredient="")
+
+    assert fetcher.last("POST", "/api/parser/ingredient") is None
+
+
+async def test_parse_ingredients_batches_in_one_request(invoke, fetcher):
+    lines = ["1/4 cup chopped onion", "2 large eggs", "a pinch of salt"]
+    out = await invoke("parse_ingredients", ingredients=lines)
+
+    assert len(fetcher.requests) == 1
+    assert fetcher.last("POST", "/api/parser/ingredients")["json"] == {
+        "ingredients": lines,
+        "parser": "nlp",
+    }
+    # one result per line, in input order
+    assert [r["input"] for r in out] == lines
+    assert out[0]["food"] == {"id": FOOD_ID, "name": "onion"}
+
+
+async def test_parse_ingredients_verbose_returns_untouched_responses(invoke, fetcher):
+    out = await invoke("parse_ingredients", ingredients=["2 eggs"], verbose=True)
+
+    assert out[0]["ingredient"]["referenceId"] == "75e1853f-3cb1-49b9-b2ca-26ae76da256b"
+
+
+async def test_parse_ingredients_rejects_empty_list(invoke, fetcher):
+    with pytest.raises(ToolError, match="Ingredients cannot be empty"):
+        await invoke("parse_ingredients", ingredients=[])
+
+    assert fetcher.last("POST", "/api/parser/ingredients") is None
+
+
+async def test_parsed_result_feeds_create_recipe_full(invoke, fetcher):
+    """The parser output must be usable as a structured ingredient verbatim."""
+    parsed = await invoke("parse_ingredient", ingredient="1/4 cup chopped onion")
+    ingredient = {
+        k: v for k, v in parsed.items() if k in ("quantity", "unit", "food", "note")
+    }
+
+    await invoke("create_recipe_full", name="Parsed", ingredients=[ingredient])
+
+    written = fetcher.last("PUT", "/api/recipes/")["json"]["recipeIngredient"][0]
+    assert written["quantity"] == 0.25
+    assert written["food"]["id"] == FOOD_ID
+    assert written["note"] == "chopped"
+
+
+async def test_parse_ingredient_surfaces_client_failure(invoke, fetcher):
+    fetcher.fail_on("/api/parser/ingredient", 500, "Parser unavailable")
+
+    with pytest.raises(ToolError, match="Error parsing ingredient"):
+        await invoke("parse_ingredient", ingredient="2 eggs")
+
+
+async def test_parse_ingredients_surfaces_client_failure(invoke, fetcher):
+    fetcher.fail_on("/api/parser/ingredients", 500, "Parser unavailable")
+
+    with pytest.raises(ToolError, match="Error parsing ingredients"):
+        await invoke("parse_ingredients", ingredients=["2 eggs"])


### PR DESCRIPTION
> Authored with [Claude Code](https://claude.com/claude-code); the commits carry a
> `Co-Authored-By` trailer. Everything described below was verified against a live
> Mealie v3.22.0 instance, not just against the test suite.

**This is a feature rather than a bug fix — entirely reasonable to decline. It's independent of my three other open PRs.**

Mealie ships a server-side ingredient parser at `/api/parser/ingredient(s)` that nothing here reached. Without it, building a recipe means resolving each ingredient by hand through `get_foods` / `get_units` — roughly one to two calls per line. For the case I care about (bulk-importing cookbook recipes, where a model reads the source and creates the recipe) that's the dominant cost. `parse_ingredients` does a whole recipe in one request.

Adds a `ParserMixin` and two tools over it. Both accept Mealie's `nlp`, `brute`, and `openai` backends and reject anything else before issuing a request.

## The one design decision worth your view

By default the tools flatten `ParsedIngredient` to `{input, confidence, quantity, unit, food, note}`, keeping the food and unit **ids** that `create_recipe_full` needs and dropping the rest of the nested records:

```
parse_ingredients(ingredients=["1/4 cup chopped onion", "2 large eggs"])
# [{"input": "1/4 cup chopped onion", "confidence": 0.996, "quantity": 0.25,
#   "unit": {"id": "...", "name": "cup"},
#   "food": {"id": "...", "name": "onion"}, "note": "chopped"}, ...]
```

That's roughly an order of magnitude fewer tokens per ingredient than the raw response, and the result is usable as a structured ingredient with no reshaping — which is the whole point for a bulk import. `verbose=True` returns Mealie's untouched response, including the per-field confidence breakdown, for when a low-confidence parse needs checking.

An unmatched food or unit stays visible as `null` rather than being dropped, so the caller can create the missing vocabulary entry instead of silently losing it.

If you'd rather these passed the raw response straight through, that's a one-line change — say the word.

## Testing

Twelve new tests: endpoint and payload for both tools, the flattening, `verbose`, parser-choice forwarding, three validation failures, two client failures, and one asserting a parsed result feeds into `create_recipe_full` verbatim.

Verified against a live Mealie v3.22.0 instance end to end — parsed four lines in one request, fed the results straight into `create_recipe_full`, and Mealie rendered `¹/₄ cup onion chopped` and `1 tablespoon za'atar`. Throwaway recipe deleted afterwards.

`ruff check src tests` and `pytest` pass (60 → 72).

---

My other three PRs are the asset-upload 422 fix, recipe nutrition, and recipe notes. Each adds a `CHANGELOG.md` that the README already links to, so whichever merges second will need a trivial conflict resolution there. Happy to rebase whenever you like.
