### PR TITLE
feat: control recipe display settings from create and patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `create_recipe_full` and `patch_recipe` accept a `settings` argument for
+  Mealie's per-recipe display toggles (`public`, `showNutrition`, `showAssets`,
+  `landscapeView`, `disableComments`, `disableAmount`, `locked`). Any subset may
+  be passed; the tools read the recipe's current settings and send the merged
+  object, so toggles left out keep their value.
+
+### Fixed
+
+- Assets and nutrition could be written but not seen. `showAssets` and
+  `showNutrition` gate the corresponding UI cards, and nothing in the server
+  could read or write them, so an asset uploaded through
+  `upload_recipe_asset_file` was present in the API response yet invisible in
+  the Mealie UI whenever the household default left the toggle off.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A comprehensive Model Context Protocol (MCP) server that enables AI assistants t
 - **Image Management**: Upload images or scrape from URLs
 - **Asset Uploads**: Attach documents and files to recipes
 - **Metadata Tracking**: Mark recipes as made, track last made dates
+- **Display Settings**: Control per-recipe visibility toggles such as showAssets and showNutrition
 
 ### 🛒 Shopping Lists
 
@@ -122,9 +123,9 @@ Restart Claude Desktop to load the server.
 - `get_recipe_detailed` - Get complete recipe details
 - `get_recipe_concise` - Get recipe summary
 - `create_recipe` - Create new recipe (flat or structured ingredients)
-- `create_recipe_full` - Create a recipe with full content in one call
+- `create_recipe_full` - Create a recipe with full content (including display settings) in one call
 - `update_recipe` - Update recipe (full replacement)
-- `patch_recipe` - Update specific fields only
+- `patch_recipe` - Update specific fields only (including display settings)
 - `duplicate_recipe` - Clone a recipe
 - `mark_recipe_last_made` - Update last made timestamp
 - `set_recipe_image_from_url` - Set image from URL
@@ -276,6 +277,25 @@ When filtering recipes, you **must use slugs or UUIDs**, not display names:
 ```
 
 Use `get_tags()` or `get_categories()` first to find the correct slugs.
+
+### Uploaded Assets and Nutrition Can Be Stored but Hidden
+
+A recipe's `settings` object controls what the UI renders. `showAssets` and
+`showNutrition` gate the assets and nutrition cards, so an asset uploaded with
+`upload_recipe_asset_file` can be present in the API response and still be
+invisible in the web UI. Flip the toggle with:
+
+```
+patch_recipe(slug="...", settings={"showAssets": True})
+```
+
+Mealie seeds a new recipe's settings from the household preferences
+(`recipeShowAssets`, `recipeShowNutrition`, ...), so the defaults differ per
+instance — check rather than assume.
+
+Only the toggles you pass are changed. The tool reads the recipe's current
+settings and sends the merged object, because Mealie does not reliably preserve
+toggles omitted from a settings PATCH.
 
 ### Field Preservation
 

--- a/src/models/recipe.py
+++ b/src/models/recipe.py
@@ -71,6 +71,51 @@ class RecipeNutrition(BaseModel):
     unsaturatedFatContent: Optional[str] = None
 
 
+class RecipeSettingsInput(BaseModel):
+    """Display toggles accepted by the create/update recipe tools.
+
+    Every field is optional: only the toggles you pass are changed, the rest
+    keep their current value. Mealie seeds a new recipe's settings from the
+    household preferences (`recipeShowAssets`, `recipeShowNutrition`, and
+    friends), so the defaults differ per instance.
+    """
+
+    public: Optional[bool] = Field(
+        default=None,
+        description="Make the recipe readable without logging in.",
+    )
+    showNutrition: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Render the nutrition card. Nutrition values are stored either way, "
+            "but stay hidden in the UI while this is false."
+        ),
+    )
+    showAssets: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Render the assets card. Uploaded assets are stored either way, but "
+            "stay hidden in the UI while this is false."
+        ),
+    )
+    landscapeView: Optional[bool] = Field(
+        default=None, description="Use the landscape recipe layout."
+    )
+    disableComments: Optional[bool] = Field(
+        default=None, description="Hide the comments section."
+    )
+    disableAmount: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Hide ingredient quantities and units. Not present on every Mealie "
+            "version; ignored where absent."
+        ),
+    )
+    locked: Optional[bool] = Field(
+        default=None, description="Prevent other users from editing the recipe."
+    )
+
+
 class RecipeSettings(BaseModel):
     public: bool = False
     showNutrition: bool = False

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -15,6 +15,7 @@ from models.recipe import (
     RecipeIngredientInput,
     RecipeInstruction,
     RecipeInstructionInput,
+    RecipeSettingsInput,
     RecipeTag,
     RecipeTool,
 )
@@ -365,6 +366,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         instructions: Optional[List[Union[str, RecipeInstructionInput]]] = None,
         tags: Optional[List[OrganizerRef]] = None,
         tools: Optional[List[OrganizerRef]] = None,
+        settings: Optional[RecipeSettingsInput] = None,
     ) -> Dict[str, Any]:
         """Create a recipe and populate all of its content in one call.
 
@@ -392,6 +394,10 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             instructions: Instruction strings and/or structured instruction objects.
             tags: Existing Mealie tags (id+name) to assign; look up with get_tags.
             tools: Existing Mealie tools (id+name) to assign; look up with get_tools.
+            settings: Display toggles to override on the new recipe. Only the
+                toggles you pass are changed; the rest keep the defaults Mealie
+                seeds from the household preferences. Set showAssets here when
+                you know you are about to attach a file.
 
         Returns:
             Dict[str, Any]: The created recipe details.
@@ -428,6 +434,11 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 recipe.tags = [RecipeTag(**_organizer_payload(t)) for t in tags]
             if tools is not None:
                 recipe.tools = [RecipeTool(**_organizer_payload(t)) for t in tools]
+            if settings is not None:
+                # merge onto the settings Mealie already seeded, so unpassed
+                # toggles keep their value instead of falling back to defaults
+                for key, value in settings.model_dump(exclude_none=True).items():
+                    setattr(recipe.settings, key, value)
             _normalize_references(recipe)
 
             updated = mealie.update_recipe(slug, recipe.model_dump(exclude_none=True))
@@ -459,6 +470,7 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         org_url: Optional[str] = None,
         tags: Optional[List[OrganizerRef]] = None,
         tools: Optional[List[OrganizerRef]] = None,
+        settings: Optional[RecipeSettingsInput] = None,
     ) -> Dict[str, Any]:
         """Partially update a recipe (only updates provided fields).
 
@@ -475,6 +487,11 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             org_url: Source URL for the recipe (shown as a link in the Mealie UI).
             tags: Existing Mealie tags (id+name) to set; look up with get_tags.
             tools: Existing Mealie tools (id+name) to set; look up with get_tools.
+            settings: Display toggles to change, e.g. showAssets to make an
+                uploaded asset visible in the UI, or showNutrition to reveal
+                stored nutrition. Only the toggles you pass are changed: the
+                current settings are read first and merged, because Mealie does
+                not reliably preserve toggles left out of a settings PATCH.
 
         Returns:
             Dict[str, Any]: The updated recipe details.
@@ -505,6 +522,14 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                 recipe_data["tags"] = [_organizer_payload(t) for t in tags]
             if tools is not None:
                 recipe_data["tools"] = [_organizer_payload(t) for t in tools]
+            if settings is not None:
+                # Mealie drops some toggles omitted from a settings PATCH, so
+                # send the complete object built from the recipe's current one
+                current = mealie.get_recipe(slug).get("settings") or {}
+                recipe_data["settings"] = {
+                    **current,
+                    **settings.model_dump(exclude_none=True),
+                }
 
             if not recipe_data:
                 raise ValueError("At least one field must be provided to update")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,16 @@ BASE_RECIPE = {
     "dateUpdated": "2024-01-01T00:00:00",
     "createdAt": "2024-01-01T00:00:00",
     "updatedAt": "2024-01-01T00:00:00",
+    # Mealie seeds these from the household preferences, so a fresh recipe does
+    # not necessarily start all-false.
+    "settings": {
+        "public": False,
+        "showNutrition": True,
+        "showAssets": True,
+        "landscapeView": False,
+        "disableComments": False,
+        "locked": True,
+    },
 }
 
 

--- a/tests/test_recipe_tools.py
+++ b/tests/test_recipe_tools.py
@@ -120,3 +120,54 @@ async def test_get_recipe_concise_includes_orgurl_tags_tools(invoke, fetcher):
     assert out["orgURL"] == "https://example.com/r"
     assert out["tags"] == [{"id": "t1", "name": "Quick", "slug": "quick"}]
     assert out["tools"][0]["name"] == "Pfanne"
+
+
+async def test_patch_recipe_merges_settings_onto_current(invoke, fetcher):
+    await invoke("patch_recipe", slug="test-recipe", settings={"showAssets": False})
+
+    body = fetcher.last("PATCH", "/api/recipes/")["json"]
+    # Mealie drops toggles omitted from a settings PATCH, so the tool reads the
+    # current object and sends it whole -- locked must survive untouched.
+    assert body["settings"] == {
+        "public": False,
+        "showNutrition": True,
+        "showAssets": False,
+        "landscapeView": False,
+        "disableComments": False,
+        "locked": True,
+    }
+
+
+async def test_patch_recipe_settings_reads_current_first(invoke, fetcher):
+    await invoke("patch_recipe", slug="test-recipe", settings={"public": True})
+
+    # the merge needs the existing settings, so a GET precedes the PATCH
+    methods = [r["method"] for r in fetcher.requests]
+    assert methods == ["GET", "PATCH"]
+
+
+async def test_patch_recipe_without_settings_issues_no_extra_get(invoke, fetcher):
+    await invoke("patch_recipe", slug="test-recipe", description="Just a description")
+
+    assert [r["method"] for r in fetcher.requests] == ["PATCH"]
+    assert "settings" not in fetcher.last("PATCH", "/api/recipes/")["json"]
+
+
+async def test_create_recipe_full_merges_settings_onto_seeded(invoke, fetcher):
+    await invoke(
+        "create_recipe_full", name="Visible", settings={"showAssets": True}
+    )
+
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    assert body["settings"]["showAssets"] is True
+    # the toggles Mealie seeded are preserved rather than reset to model defaults
+    assert body["settings"]["locked"] is True
+    assert body["settings"]["showNutrition"] is True
+
+
+async def test_create_recipe_full_without_settings_preserves_seeded(invoke, fetcher):
+    await invoke("create_recipe_full", name="Plain")
+
+    body = fetcher.last("PUT", "/api/recipes/")["json"]
+    assert body["settings"]["locked"] is True
+    assert body["settings"]["showAssets"] is True


### PR DESCRIPTION
> Authored with [Claude Code](https://claude.com/claude-code); the commit carries a
> `Co-Authored-By` trailer. Everything described below was verified against a live
> Mealie v3.22.0 instance, not just against the test suite.

A recipe's `settings` object decides what the UI renders. `showAssets` and `showNutrition` gate the assets and nutrition cards, so a file uploaded with `upload_recipe_asset_file` can sit in the recipe's `assets` array — visible over the API — and still not appear in the web UI. Nothing in the server could read or write those toggles.

Adds an optional `settings` argument to `create_recipe_full` and `patch_recipe`.

This is independent of my other open PRs (#18–#21) and branches off `main`.

## Shape

A nested `RecipeSettingsInput` model rather than seven flat parameters, matching how `nutrition` and `notes` are already shaped and keeping `create_recipe_full`'s signature from growing another seven arguments.

## Read-then-merge, not pass-through

Both paths read the current settings and send the complete object. A partial settings PATCH does **not** reliably preserve the toggles left out. Starting from all-true and patching only `showAssets`:

```
before:  public=T showNutrition=T showAssets=T landscapeView=T disableComments=T locked=T
PATCH    {"settings": {"showAssets": false}}
after:   public=T showNutrition=T showAssets=F landscapeView=T disableComments=F locked=F
                                                                ^^^^^^^^^^^^^^^^  ^^^^^^^
```

`public`, `showNutrition`, and `landscapeView` survived; `disableComments` and `locked` reset. **I could not work out the rule behind that split** — it isn't a clean replace (a replace would have reset `public` too) and it isn't a clean merge. Sending the complete object round-trips every key reliably, which is what the tools now do.

Merging matters more here than for `nutrition`, where these tools replace wholesale: these are booleans whose defaults carry meaning, so clobbering an unpassed key can silently unlock or publish a recipe. If you'd prefer consistency with `nutrition`'s replace-and-document approach, I'll switch it — but the failure mode seemed worth the extra GET.

## Two things worth knowing

- **The defaults come from household preferences**, not from a fixed value — Mealie seeds a new recipe's settings from `recipeShowAssets`, `recipeShowNutrition`, and friends, so they vary per instance and per household. Flipping those is the workaround for the symptom above, but it only changes the seed for *new* recipes: it can't reveal an asset on a recipe that already exists, which still needs these tools.
- **`disableAmount` is in the OpenAPI schema for `RecipeSettings` but is not returned by 3.22.0.** It's accepted as an input field and ignored where absent; the read-then-merge passes through any key the instance actually has, so this stays version-agnostic.

## Testing

Five new tests: the merge onto current settings, that a GET precedes the PATCH, that omitting `settings` adds no extra GET, and both create-time cases. `BASE_RECIPE` in `conftest.py` gained a settings block that is deliberately *not* all-false, so a test that clobbered unpassed toggles would fail.

Live: created a recipe with `showAssets`/`showNutrition` off and `locked`/`public` on, uploaded a PDF, confirmed it was stored but hidden, then flipped each toggle and confirmed exactly one key changed each time with `locked` and `public` untouched, and the nutrition and asset data intact throughout. Throwaway recipe deleted.

`ruff check src tests` and `pytest` pass (60 → 65 on this branch).
