### PR TITLE
feat: add MCP tool for AI-driven recipe importation

### DIFF
--- a/src/mealie/recipe.py
+++ b/src/mealie/recipe.py
@@ -148,7 +148,7 @@ class RecipeMixin:
         translate_language: Optional[str] = None,
         create_new_organizers: Optional[bool] = None,
         images: Optional[List[str]] = None,
-    ) -> Dict[str, Any]:
+    ) -> str:
         """Create a recipe using AI from raw text, a URL, and/or images
 
         Args:
@@ -159,7 +159,7 @@ class RecipeMixin:
             images: List of image data (e.g. base64-encoded strings) to extract a recipe from
 
         Returns:
-            JSON response containing the newly created recipe details
+            Slug of the newly created recipe
         """
         payload = {
             "content": content,

--- a/src/mealie/recipe.py
+++ b/src/mealie/recipe.py
@@ -141,6 +141,38 @@ class RecipeMixin:
             json={"url": url, "includeTags": include_tags},
         )
 
+    def import_recipe_with_ai(
+        self,
+        content: Optional[str] = None,
+        url: Optional[str] = None,
+        translate_language: Optional[str] = None,
+        create_new_organizers: Optional[bool] = None,
+        images: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Create a recipe using AI from raw text, a URL, and/or images
+
+        Args:
+            content: Raw text content to extract a recipe from
+            url: Source URL to extract a recipe from
+            translate_language: Language code to translate the extracted recipe into
+            create_new_organizers: If True, allow the AI to create new tags/categories
+            images: List of image data (e.g. base64-encoded strings) to extract a recipe from
+
+        Returns:
+            JSON response containing the newly created recipe details
+        """
+        payload = {
+            "content": content,
+            "url": url,
+            "translateLanguage": translate_language,
+            "createNewOrganizers": create_new_organizers,
+            "images": images,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        logger.info({"message": "Importing recipe with AI", "url": url})
+        return self._handle_request("POST", "/api/recipes/create/ai", json=payload)
+
     def patch_recipe(self, slug: str, recipe_data: Dict[str, Any]) -> Dict[str, Any]:
         """Partially update a recipe (only updates provided fields)
 

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -315,6 +315,54 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
             raise ToolError(error_msg)
 
     @mcp.tool()
+    def import_recipe_with_ai(
+        content: Optional[str] = None,
+        url: Optional[str] = None,
+        translate_language: Optional[str] = None,
+        create_new_organizers: Optional[bool] = None,
+        images: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Import/create a recipe using Mealie's AI extraction.
+
+        Give it raw text, a URL, and/or images and Mealie's AI will extract a
+        structured recipe (name, ingredients, instructions, etc.). At least one
+        of content, url, or images should be provided.
+
+        Args:
+            content: Raw text to extract a recipe from (e.g. a pasted recipe or email).
+            url: Source URL to extract a recipe from.
+            translate_language: Language code to translate the extracted recipe into (e.g. "en").
+            create_new_organizers: If True, allow the AI to create new tags/categories.
+            images: List of image data (e.g. base64-encoded strings) to extract a recipe from.
+
+        Returns:
+            Dict[str, Any]: The created recipe details.
+        """
+        try:
+            logger.info(
+                {
+                    "message": "Importing recipe with AI",
+                    "url": url,
+                    "has_content": content is not None,
+                    "image_count": len(images) if images else 0,
+                }
+            )
+            return mealie.import_recipe_with_ai(
+                content=content,
+                url=url,
+                translate_language=translate_language,
+                create_new_organizers=create_new_organizers,
+                images=images,
+            )
+        except Exception as e:
+            error_msg = f"Error importing recipe with AI: {str(e)}"
+            logger.error({"message": error_msg})
+            logger.debug(
+                {"message": "Error traceback", "traceback": traceback.format_exc()}
+            )
+            raise ToolError(error_msg)
+
+    @mcp.tool()
     def update_recipe(
         slug: str,
         ingredients: List[Union[str, RecipeIngredientInput]],

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -353,13 +353,14 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
                     "image_count": len(images) if images else 0,
                 }
             )
-            return mealie.import_recipe_with_ai(
+            slug = mealie.import_recipe_with_ai(
                 content=content,
                 url=url,
                 translate_language=translate_language,
                 create_new_organizers=create_new_organizers,
                 images=images,
             )
+            return mealie.get_recipe(slug)
         except Exception as e:
             error_msg = f"Error importing recipe with AI: {str(e)}"
             logger.error({"message": error_msg})

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -338,13 +338,15 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         Returns:
             Dict[str, Any]: The created recipe details.
         """
-        content = content.strip() if isinstance(content, str) else content
-        url = url.strip() if isinstance(url, str) else url
-        if not content and not url and not images:
-            raise ToolError("At least one of content, url, or images must be provided")
-        if images is not None and len(images) == 0:
-            images = None
         try:
+            # Normalize inputs: whitespace-only strings to None, empty lists to None
+            content = content.strip() if isinstance(content, str) and content.strip() else None
+            url = url.strip() if isinstance(url, str) and url.strip() else None
+            images = images if images else None
+
+            if not any([content, url, images]):
+                raise ValueError("At least one of 'content', 'url', or 'images' must be provided.")
+
             logger.info(
                 {
                     "message": "Importing recipe with AI",

--- a/src/tools/recipe_tools.py
+++ b/src/tools/recipe_tools.py
@@ -338,12 +338,18 @@ def register_recipe_tools(mcp: FastMCP, mealie: MealieFetcher) -> None:
         Returns:
             Dict[str, Any]: The created recipe details.
         """
+        content = content.strip() if isinstance(content, str) else content
+        url = url.strip() if isinstance(url, str) else url
+        if not content and not url and not images:
+            raise ToolError("At least one of content, url, or images must be provided")
+        if images is not None and len(images) == 0:
+            images = None
         try:
             logger.info(
                 {
                     "message": "Importing recipe with AI",
                     "url": url,
-                    "has_content": content is not None,
+                    "has_content": bool(content),
                     "image_count": len(images) if images else 0,
                 }
             )

--- a/tests/test_recipe_tools.py
+++ b/tests/test_recipe_tools.py
@@ -168,5 +168,6 @@ async def test_import_recipe_with_ai_includes_optional_fields_when_set(invoke, f
 
 
 async def test_import_recipe_with_ai_requires_at_least_one_input(invoke, fetcher):
-    with pytest.raises(ToolError):
+    with pytest.raises(ToolError) as excinfo:
         await invoke("import_recipe_with_ai")
+    assert "At least one of 'content', 'url', or 'images' must be provided." in str(excinfo.value)

--- a/tests/test_recipe_tools.py
+++ b/tests/test_recipe_tools.py
@@ -1,6 +1,9 @@
 """Tests for the recipe-authoring tools (structured ingredients, full create,
 patch fields, concise output)."""
 
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+
 
 async def test_create_recipe_accepts_flat_and_structured(invoke, fetcher):
     await invoke(
@@ -120,3 +123,50 @@ async def test_get_recipe_concise_includes_orgurl_tags_tools(invoke, fetcher):
     assert out["orgURL"] == "https://example.com/r"
     assert out["tags"] == [{"id": "t1", "name": "Quick", "slug": "quick"}]
     assert out["tools"][0]["name"] == "Pfanne"
+
+
+# --- import_recipe_with_ai: request shape and validation --------------------
+
+
+async def test_import_recipe_with_ai_content_only(invoke, fetcher):
+    await invoke("import_recipe_with_ai", content="2 eggs, fry them")
+    body = fetcher.last("POST", "/api/recipes/create/ai")["json"]
+    assert body == {"content": "2 eggs, fry them"}
+
+
+async def test_import_recipe_with_ai_url_only(invoke, fetcher):
+    await invoke("import_recipe_with_ai", url="https://example.com/recipe")
+    body = fetcher.last("POST", "/api/recipes/create/ai")["json"]
+    assert body == {"url": "https://example.com/recipe"}
+
+
+async def test_import_recipe_with_ai_images_only(invoke, fetcher):
+    await invoke("import_recipe_with_ai", images=["base64-image-data"])
+    body = fetcher.last("POST", "/api/recipes/create/ai")["json"]
+    assert body == {"images": ["base64-image-data"]}
+
+
+async def test_import_recipe_with_ai_omits_optional_fields_when_none(invoke, fetcher):
+    await invoke("import_recipe_with_ai", content="raw text")
+    body = fetcher.last("POST", "/api/recipes/create/ai")["json"]
+    assert "url" not in body
+    assert "translateLanguage" not in body
+    assert "createNewOrganizers" not in body
+    assert "images" not in body
+
+
+async def test_import_recipe_with_ai_includes_optional_fields_when_set(invoke, fetcher):
+    await invoke(
+        "import_recipe_with_ai",
+        content="raw text",
+        translate_language="en",
+        create_new_organizers=True,
+    )
+    body = fetcher.last("POST", "/api/recipes/create/ai")["json"]
+    assert body["translateLanguage"] == "en"
+    assert body["createNewOrganizers"] is True
+
+
+async def test_import_recipe_with_ai_requires_at_least_one_input(invoke, fetcher):
+    with pytest.raises(ToolError):
+        await invoke("import_recipe_with_ai")


### PR DESCRIPTION
## Description

This Pull Request introduces a new Model Context Protocol (MCP) tool that allows AI agents to leverage Mealie's AI-driven recipe extraction. By interfacing with the `/api/recipes/create/ai` endpoint, agents can programmatically convert unstructured text, URLs, or image data into structured recipes.

## Changes

- Added an `import_recipe_with_ai` method to the `RecipeMixin` client (`src/mealie/recipe.py`), issuing a `POST` request to `/api/recipes/create/ai`.
- Exposed a new `import_recipe_with_ai` MCP tool in `src/tools/recipe_tools.py`, wrapping the client method for agent use.
- Supported inputs: raw text (`content`), a source URL (`url`), and base64-encoded `images`.
- Optional parameters: `translate_language` to translate the extracted recipe, and `create_new_organizers` to let the AI create new tags and categories.
- Optional payload fields are omitted from the request when not provided, and failures are surfaced through the standard MCP error path with structured logging.

## Related Issues

Closes #25

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in difficult-to-understand areas.
- [x] My changes generate no new warnings.
